### PR TITLE
Enable Wagtail document usage view

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -317,6 +317,11 @@ WAGTAILSEARCH_BACKENDS = {
     }
 }
 
+
+# Allow images, media and docs to get an expensive "usage" page in the admin
+# https://docs.wagtail.org/en/v2.8.1/reference/settings.html#usage-for-images-documents-and-snippets
+WAGTAIL_USAGE_COUNT_ENABLED = True
+
 # Add a custom provider
 # Your custom provider must support oEmbed for this to work. You should be
 # able to find these details in the provider's documentation.


### PR DESCRIPTION
It can run expensive queries but presumably only when actually used. Gives content people a link in the document edit page showing them where specific docs are linked to, to make it easier to manage which docs should be live and which can be deleted etc.

https://docs.wagtail.org/en/v2.8.1/reference/settings.html#usage-for-images-documents-and-snippets