### PR TITLE
WCM-43: add sanitize function for search queries

### DIFF
--- a/search/search.py
+++ b/search/search.py
@@ -2,6 +2,7 @@ from typing import Any, Optional
 
 from django.db.models import QuerySet
 from django.http import HttpRequest
+import re
 from wagtail.search.backends import get_search_backend
 from wagtail.search.utils import parse_query_string
 
@@ -51,3 +52,10 @@ def _person_query(request: HttpRequest) -> QuerySet:
 
 def _team_query(request: HttpRequest) -> QuerySet:
     return Team.objects.all()
+
+
+def sanitize_search_query(query: str) -> str:
+    if query is None:
+        return ""
+
+    return re.sub('[^a-zA-Z0-9-.~_\s]', "", query)

--- a/search/search.py
+++ b/search/search.py
@@ -1,4 +1,5 @@
 from typing import Any, Optional
+import unicodedata
 
 from django.db.models import QuerySet
 from django.http import HttpRequest
@@ -54,8 +55,12 @@ def _team_query(request: HttpRequest) -> QuerySet:
     return Team.objects.all()
 
 
-def sanitize_search_query(query: Optional[str]) -> str:
+def sanitize_search_query(query: Optional[str] = None) -> str:
     if query is None:
         return ""
 
-    return re.sub('[^a-zA-Z0-9-.~_\s]', "", query)
+    output = re.sub('[^a-zA-Z0-9-.~_\s]', "", query)
+    if not unicodedata.is_normalized("NFKD", output):
+        output = unicodedata.normalize("NFKD", output)
+
+    return output

--- a/search/search.py
+++ b/search/search.py
@@ -1,9 +1,9 @@
-from typing import Any, Optional
+import re
 import unicodedata
+from typing import Any, Optional
 
 from django.db.models import QuerySet
 from django.http import HttpRequest
-import re
 from wagtail.search.backends import get_search_backend
 from wagtail.search.utils import parse_query_string
 
@@ -59,7 +59,7 @@ def sanitize_search_query(query: Optional[str] = None) -> str:
     if query is None:
         return ""
 
-    output = re.sub('[^a-zA-Z0-9-.~_\s]', "", query)
+    output = re.sub(r"[^a-zA-Z0-9-.~_\s]", "", query)
     if not unicodedata.is_normalized("NFKD", output):
         output = unicodedata.normalize("NFKD", output)
 

--- a/search/search.py
+++ b/search/search.py
@@ -76,14 +76,14 @@ def sanitize_search_query(query: Optional[str] = None) -> str:
             quote_next_match = False  # closing quote found
             continue
 
-        # replace all url-unsafe chars
+        # ascii-fold all chars that can be folded
+        match = unicodedata.normalize("NFKD", match)
+
+        # replace all remaining url-unsafe chars
         cleaned_match = re.sub(r"[^a-zA-Z0-9-.~_\s]", "", match)
         if quote_next_match:
             cleaned_match = f"'{cleaned_match}'"
 
         output += cleaned_match
-
-    if not unicodedata.is_normalized("NFKD", output):
-        output = unicodedata.normalize("NFKD", output)
 
     return output

--- a/search/search.py
+++ b/search/search.py
@@ -55,14 +55,16 @@ def _team_query(request: HttpRequest) -> QuerySet:
     return Team.objects.all()
 
 
-def sanitize_search_query(query = None) -> str:
+def sanitize_search_query(query: Optional[str] = None) -> str:
     if query is None:
         return ""
+
     # find all properly quoted substrings with matching opening and closing "|'
     matches = re.split(r"([\"'])(.*?)(\1)", query)
+
     output = ""
     quote_next_match = False
-    valid_quotes = ["\"", "'"]
+    valid_quotes = ['"', "'"]
     for match in matches:
         if match == "":
             continue
@@ -78,6 +80,8 @@ def sanitize_search_query(query = None) -> str:
         output += re.sub(r"[^a-zA-Z0-9-.~_\s]", "", match)
         if quote_next_match:
             output += "'"
+
     if not unicodedata.is_normalized("NFKD", output):
         output = unicodedata.normalize("NFKD", output)
+
     return output

--- a/search/search.py
+++ b/search/search.py
@@ -54,7 +54,7 @@ def _team_query(request: HttpRequest) -> QuerySet:
     return Team.objects.all()
 
 
-def sanitize_search_query(query: str) -> str:
+def sanitize_search_query(query: Optional[str]) -> str:
     if query is None:
         return ""
 

--- a/search/search.py
+++ b/search/search.py
@@ -60,6 +60,7 @@ def sanitize_search_query(query: Optional[str] = None) -> str:
         return ""
 
     # find all properly quoted substrings with matching opening and closing "|'
+    # re.split returns both matches and unmatched parts so we process everything
     matches = re.split(r"([\"'])(.*?)(\1)", query)
 
     output = ""
@@ -74,12 +75,13 @@ def sanitize_search_query(query: Optional[str] = None) -> str:
         if match in valid_quotes and quote_next_match:
             quote_next_match = False  # closing quote found
             continue
-        if quote_next_match:
-            output += "'"
+
         # replace all url-unsafe chars
-        output += re.sub(r"[^a-zA-Z0-9-.~_\s]", "", match)
+        cleaned_match = re.sub(r"[^a-zA-Z0-9-.~_\s]", "", match)
         if quote_next_match:
-            output += "'"
+            cleaned_match = f"'{cleaned_match}'"
+
+        output += cleaned_match
 
     if not unicodedata.is_normalized("NFKD", output):
         output = unicodedata.normalize("NFKD", output)

--- a/search/test/test_search.py
+++ b/search/test/test_search.py
@@ -2,6 +2,7 @@ from django.test import Client, TestCase
 
 from search.search import sanitize_search_query
 
+
 class TestSearchUtils(TestCase):
     def test_sanitize_asciifolds_accented_chars(self):
         query = "Gôod morninç øæå"
@@ -33,7 +34,6 @@ class TestSearchUtils(TestCase):
         result = sanitize_search_query(query)
         self.assertEqual(result, "C C")
 
-
     def test_sanitize_returns_str_containing_only_safe_chars(self):
         query = None
         result = sanitize_search_query(query)
@@ -46,7 +46,6 @@ class TestSearchUtils(TestCase):
         query = "!/(^&*)\\+{[@]}"
         result = sanitize_search_query(query)
         self.assertEqual(result, "")
-
 
     def test_sanitize_preserves_query_terms_and_phrases(self):
         query = "query"
@@ -68,8 +67,9 @@ class TestSearchUtils(TestCase):
         # only preserve single level deep
         query = "a 'very complex' query with '\"multiple nested\" phrases'"
         result = sanitize_search_query(query)
-        self.assertEqual(result, "a 'very complex' query with 'multiple nested phrases'")
-
+        self.assertEqual(
+            result, "a 'very complex' query with 'multiple nested phrases'"
+        )
 
     def test_sanitize_rationalises_valid_quotes(self):
         query = "a 'phrased' query"

--- a/search/test/test_search.py
+++ b/search/test/test_search.py
@@ -1,99 +1,77 @@
+import pytest
 from django.test import Client, TestCase
 
 from search.search import sanitize_search_query
 
 
-class TestSearchUtils(TestCase):
-    def test_sanitize_asciifolds_accented_chars(self):
-        query = "Gôod morninç øæå"
-        result = sanitize_search_query(query)
-        self.assertEqual(result, "Good morninc a")
-
-        query = "Mieux vaut être seul que mal accompagné"
-        result = sanitize_search_query(query)
-        self.assertEqual(result, "Mieux vaut etre seul que mal accompagne")
-
-        query = "Après la pluie, le beau temps"
-        result = sanitize_search_query(query)
-        self.assertEqual(result, "Apres la pluie le beau temps")
-
-        query = "À bon chat, bon rat"
-        result = sanitize_search_query(query)
-        self.assertEqual(result, "A bon chat bon rat")
-
-        query = "Lăpușneanu"
-        result = sanitize_search_query(query)
-        self.assertEqual(result, "Lapusneanu")
-
-        query = "Пожалуйста"
-        result = sanitize_search_query(query)
-        self.assertEqual(result, "")
-
+@pytest.mark.parametrize(
+    "query,result",
+    [
+        ("Gôod morninç øæå", "Good morninc a"),
+        (
+            "Mieux vaut être seul que mal accompagné",
+            "Mieux vaut etre seul que mal accompagne",
+        ),
+        ("Après la pluie, le beau temps", "Apres la pluie le beau temps"),
+        ("À bon chat, bon rat", "A bon chat bon rat"),
+        ("Lăpușneanu", "Lapusneanu"),
+        ("Пожалуйста", ""),
         # ensure composite chars are also folded
-        query = "Ç \u0043\u0327"
-        result = sanitize_search_query(query)
-        self.assertEqual(result, "C C")
+        ("Ç is the same as \u0043\u0327", "C is the same as C"),
+    ],
+)
+def test_sanitize_asciifolds_accented_chars(query, result):
+    assert sanitize_search_query(query) == result
 
-    def test_sanitize_returns_str_containing_only_safe_chars(self):
-        query = None
-        result = sanitize_search_query(query)
-        self.assertEqual(result, "")
 
-        query = "¯\_(ツ)_/¯"
-        result = sanitize_search_query(query)
-        self.assertEqual(result, " __ ")
+@pytest.mark.parametrize(
+    "query,result",
+    [
+        (None, ""),
+        ("¯\_(ツ)_/¯", " __ "),
+        ("!/(^&*)\\+{[@]}", ""),
+    ],
+)
+def test_sanitize_returns_str_containing_only_safe_chars(query, result):
+    assert sanitize_search_query(query) == result
 
-        query = "!/(^&*)\\+{[@]}"
-        result = sanitize_search_query(query)
-        self.assertEqual(result, "")
 
-    def test_sanitize_preserves_query_terms_and_phrases(self):
-        query = "query"
-        result = sanitize_search_query(query)
-        self.assertEqual(result, query)
-
-        query = "a basic query"
-        result = sanitize_search_query(query)
-        self.assertEqual(result, query)
-
-        query = "a 'more complex' query"
-        result = sanitize_search_query(query)
-        self.assertEqual(result, query)
-
-        query = "a 'very complex' query with 'multiple phrases'"
-        result = sanitize_search_query(query)
-        self.assertEqual(result, query)
-
+@pytest.mark.parametrize(
+    "query,result",
+    [
+        ("query", "query"),
+        ("a basic query", "a basic query"),
+        ("a 'more complex' query", "a 'more complex' query"),
+        (
+            "a 'very complex' query with 'multiple phrases'",
+            "a 'very complex' query with 'multiple phrases'",
+        ),
         # only preserve single level deep
-        query = "a 'very complex' query with '\"multiple nested\" phrases'"
-        result = sanitize_search_query(query)
-        self.assertEqual(
-            result, "a 'very complex' query with 'multiple nested phrases'"
-        )
+        (
+            "a 'very complex' query with '\"multiple nested\" phrases'",
+            "a 'very complex' query with 'multiple nested phrases'",
+        ),
+    ],
+)
+def test_sanitize_preserves_query_terms_and_phrases(query, result):
+    assert sanitize_search_query(query) == result
 
-    def test_sanitize_rationalises_valid_quotes(self):
-        query = "a 'phrased' query"
-        result = sanitize_search_query(query)
-        self.assertEqual(result, query)
 
+@pytest.mark.parametrize(
+    "query,result",
+    [
+        ("a 'phrased' query", "a 'phrased' query"),
         # quote styles are rationalised
-        query = 'another "phrased" query'
-        result = sanitize_search_query(query)
-        self.assertEqual(result, "another 'phrased' query")
-
-        query = 'a "misquoted query'
-        result = sanitize_search_query(query)
-        self.assertEqual(result, "a misquoted query")
-
-        query = "another misquoted' query"
-        result = sanitize_search_query(query)
-        self.assertEqual(result, "another misquoted query")
-
+        ('another "phrased" query', "another 'phrased' query"),
+        ('a "misquoted query', "a misquoted query"),
+        ("another misquoted' query", "another misquoted query"),
         # it will always match the first and second quotes of the same type
-        query = "a misquoted' query with 'a phrase'"
-        result = sanitize_search_query(query)
-        self.assertEqual(result, "a misquoted' query with 'a phrase")
-
-        query = "a misquoted 'query with' 'several' 'phrases"
-        result = sanitize_search_query(query)
-        self.assertEqual(result, "a misquoted 'query with' 'several' phrases")
+        ("a misquoted' query with 'a phrase'", "a misquoted' query with 'a phrase"),
+        (
+            "a misquoted 'query with' 'several' 'phrases",
+            "a misquoted 'query with' 'several' phrases",
+        ),
+    ],
+)
+def test_sanitize_rationalises_valid_quotes(query, result):
+    assert sanitize_search_query(query) == result

--- a/search/test/test_search.py
+++ b/search/test/test_search.py
@@ -1,0 +1,99 @@
+from django.test import Client, TestCase
+
+from search.search import sanitize_search_query
+
+class TestSearchUtils(TestCase):
+    def test_sanitize_asciifolds_accented_chars(self):
+        query = "Gôod morninç øæå"
+        result = sanitize_search_query(query)
+        self.assertEqual(result, "Good morninc a")
+
+        query = "Mieux vaut être seul que mal accompagné"
+        result = sanitize_search_query(query)
+        self.assertEqual(result, "Mieux vaut etre seul que mal accompagne")
+
+        query = "Après la pluie, le beau temps"
+        result = sanitize_search_query(query)
+        self.assertEqual(result, "Apres la pluie le beau temps")
+
+        query = "À bon chat, bon rat"
+        result = sanitize_search_query(query)
+        self.assertEqual(result, "A bon chat bon rat")
+
+        query = "Lăpușneanu"
+        result = sanitize_search_query(query)
+        self.assertEqual(result, "Lapusneanu")
+
+        query = "Пожалуйста"
+        result = sanitize_search_query(query)
+        self.assertEqual(result, "")
+
+        # ensure composite chars are also folded
+        query = "Ç \u0043\u0327"
+        result = sanitize_search_query(query)
+        self.assertEqual(result, "C C")
+
+
+    def test_sanitize_returns_str_containing_only_safe_chars(self):
+        query = None
+        result = sanitize_search_query(query)
+        self.assertEqual(result, "")
+
+        query = "¯\_(ツ)_/¯"
+        result = sanitize_search_query(query)
+        self.assertEqual(result, " __ ")
+
+        query = "!/(^&*)\\+{[@]}"
+        result = sanitize_search_query(query)
+        self.assertEqual(result, "")
+
+
+    def test_sanitize_preserves_query_terms_and_phrases(self):
+        query = "query"
+        result = sanitize_search_query(query)
+        self.assertEqual(result, query)
+
+        query = "a basic query"
+        result = sanitize_search_query(query)
+        self.assertEqual(result, query)
+
+        query = "a 'more complex' query"
+        result = sanitize_search_query(query)
+        self.assertEqual(result, query)
+
+        query = "a 'very complex' query with 'multiple phrases'"
+        result = sanitize_search_query(query)
+        self.assertEqual(result, query)
+
+        # only preserve single level deep
+        query = "a 'very complex' query with '\"multiple nested\" phrases'"
+        result = sanitize_search_query(query)
+        self.assertEqual(result, "a 'very complex' query with 'multiple nested phrases'")
+
+
+    def test_sanitize_rationalises_valid_quotes(self):
+        query = "a 'phrased' query"
+        result = sanitize_search_query(query)
+        self.assertEqual(result, query)
+
+        # quote styles are rationalised
+        query = 'another "phrased" query'
+        result = sanitize_search_query(query)
+        self.assertEqual(result, "another 'phrased' query")
+
+        query = 'a "misquoted query'
+        result = sanitize_search_query(query)
+        self.assertEqual(result, "a misquoted query")
+
+        query = "another misquoted' query"
+        result = sanitize_search_query(query)
+        self.assertEqual(result, "another misquoted query")
+
+        # it will always match the first and second quotes of the same type
+        query = "a misquoted' query with 'a phrase'"
+        result = sanitize_search_query(query)
+        self.assertEqual(result, "a misquoted' query with 'a phrase")
+
+        query = "a misquoted 'query with' 'several' 'phrases"
+        result = sanitize_search_query(query)
+        self.assertEqual(result, "a misquoted 'query with' 'several' phrases")

--- a/search/test/test_search.py
+++ b/search/test/test_search.py
@@ -1,5 +1,4 @@
 import pytest
-from django.test import Client, TestCase
 
 from search.search import sanitize_search_query
 

--- a/search/views.py
+++ b/search/views.py
@@ -33,8 +33,6 @@ def search(request):
 
     # OR based search apart from anything quoted
     sanitized_search_query = sanitize_search_query(search_query)
-    print("*************************")
-    print(sanitized_search_query)
 
     query_parts = shlex.split(sanitized_search_query.lower())
     search_terms = ""

--- a/search/views.py
+++ b/search/views.py
@@ -33,8 +33,6 @@ def search(request):
 
     # OR based search apart from anything quoted
     sanitized_search_query = sanitize_search_query(search_query)
-    print("**********")
-    print(sanitized_search_query)
 
     query_parts = shlex.split(sanitized_search_query.lower())
     search_terms = ""

--- a/search/views.py
+++ b/search/views.py
@@ -14,7 +14,7 @@ from elasticsearch_dsl import Search
 from content.models import ContentPage, SearchExclusionPageLookUp, SearchPinPageLookUp
 
 from .forms import SearchCategory, SearchForm
-from .search import search_all
+from .search import sanitize_search_query, search_all
 
 
 logger = logging.getLogger(__name__)
@@ -32,8 +32,11 @@ def search(request):
     total_shown = 10
 
     # OR based search apart from anything quoted
+    sanitized_search_query = sanitize_search_query(search_query)
+    print("**********")
+    print(sanitized_search_query)
 
-    query_parts = shlex.split(search_query.lower())
+    query_parts = shlex.split(sanitized_search_query.lower())
     search_terms = ""
 
     for query_part in query_parts:

--- a/search/views.py
+++ b/search/views.py
@@ -33,6 +33,8 @@ def search(request):
 
     # OR based search apart from anything quoted
     sanitized_search_query = sanitize_search_query(search_query)
+    print("*************************")
+    print(sanitized_search_query)
 
     query_parts = shlex.split(sanitized_search_query.lower())
     search_terms = ""


### PR DESCRIPTION
People entering various non-URL-safe chars break the search function

https://sentry.ci.uktrade.digital/organizations/dit/issues/71022/?project=161

This PR removes those characters from the query silently, allowing for more likely matching. 

It also preserves quoted search phrases, but parses all their contents to remove unsafe chars. Phrases are only recognised if properly quoted inside matching pairs of quotes - either `'` or `"`. These quote marks are preservable because the legacy query building functionality treats them as a special case and processes them accordingly.