### PR TITLE
headings and result types split out for extra uses

### DIFF
--- a/search/templates/search/partials/search_results_all.html
+++ b/search/templates/search/partials/search_results_all.html
@@ -3,15 +3,15 @@
 <div class="search-results__all">
     <div class="left-col">
         <div class="pages">
-            {% search_category category='all_pages' heading='page' %}
+            {% search_category category='all_pages' show_heading=True %}
         </div>
     </div>
     <div class="right-col">
         <div class="people">
-            {% search_category category='people' limit=3 heading='person' heading_plural='people' %}
+            {% search_category category='people' limit=3 show_heading=True %}
         </div>
         <div class="teams">
-            {% search_category category='teams' limit=3 heading='team' %}
+            {% search_category category='teams' limit=3 show_heading=True %}
         </div>
     </div>
 </div>

--- a/search/templates/search/partials/search_results_category.html
+++ b/search/templates/search/partials/search_results_category.html
@@ -1,12 +1,12 @@
 <div class="search-results__category">
-    {% if heading %}
-        <h3 class="govuk-heading-s">{{ count }} {{ heading }}</h3>
+    {% if show_heading %}
+        <h3 class="govuk-heading-s">{{ count }} {{ result_type_display }}</h3>
     {% endif %}
 {{page}}
     <div class="search-results__list" data-search-category="{{ search_category }}">
         {% if pinned_results %}
             <div class="pinned">
-                <h3 class="govuk-heading-s">Featured {{ heading }}</h3>
+                <h3 class="govuk-heading-s">Featured {{ result_type_display }}</h3>
 
                     {% for result in pinned_results %}
                         {% include search_results_item_template with object=result type=search_category section="pinned" number_overall=forloop.counter number_section=forloop.counter only %}
@@ -20,7 +20,7 @@
             {% endfor %}
 
         {% else %}
-            <p class="govuk-body">There are no matching {{ heading|default:"results" }}.</p>
+            <p class="govuk-body">There are no matching {{ result_type_display }}.</p>
 
             {% if search_category == 'all_pages' %}
             {% comment %} Only show this in the main pages section of the "all" results {% endcomment %}


### PR DESCRIPTION
sometimes we need the result type for things like "featured guidance pages" or "there are no tools matching your search" UI elements even if we're not showing headings