### PR TITLE
Only return the actions markup if the links are being shown

### DIFF
--- a/src/peoplefinder/templates/peoplefinder/partials/profile-completion-field-link.html
+++ b/src/peoplefinder/templates/peoplefinder/partials/profile-completion-field-link.html
@@ -1,3 +1,5 @@
 {% if show_link %}
-    <a class="govuk-button govuk-!-margin-0" href="{{ profile_edit_url }}">Add {{ human_readable_field_name }}</a>
+    <dd class="govuk-summary-list__actions">
+        <a class="govuk-button govuk-!-margin-0" href="{{ profile_edit_url }}">Add {{ human_readable_field_name }}</a>
+    </dd>
 {% endif %}

--- a/src/peoplefinder/templates/peoplefinder/profile.html
+++ b/src/peoplefinder/templates/peoplefinder/profile.html
@@ -168,9 +168,7 @@
                             <a href="tel:{{ profile.primary_phone_number }}" class="govuk-link">{{ profile.primary_phone_number }}</a>
                         {% endif %}
                     </dd>
-                    <dd class="govuk-summary-list__actions">
-                        {% profile_completion_field_link "primary_phone_number" profile %}
-                    </dd>
+                    {% profile_completion_field_actions "primary_phone_number" profile %}
                 </div>
 
                 {% if profile.secondary_phone_number %}
@@ -200,9 +198,7 @@
                                data-testid="manager">{{ profile.manager.full_name }}</a>
                         {% endif %}
                     </dd>
-                    <dd class="govuk-summary-list__actions">
-                        {% profile_completion_field_link "manager" profile %}
-                    </dd>
+                    {% profile_completion_field_actions "manager" profile %}
                 </div>
 
                 {% if profile.workdays.exists %}
@@ -327,9 +323,7 @@
                     <dd class="govuk-summary-list__value">
                         {% if profile.town_city_or_region %}{{ profile.town_city_or_region }}{% endif %}
                     </dd>
-                    <dd class="govuk-summary-list__actions">
-                        {% profile_completion_field_link "town_city_or_region" profile %}
-                    </dd>
+                    {% profile_completion_field_actions "town_city_or_region" profile %}
                 </div>
 
                 <div class="govuk-summary-list__row">
@@ -337,9 +331,7 @@
                     <dd class="govuk-summary-list__value">
                         {% if profile.country %}{{ profile.country }}{% endif %}
                     </dd>
-                    <dd class="govuk-summary-list__actions">
-                        {% profile_completion_field_link "country" profile %}
-                    </dd>
+                    {% profile_completion_field_actions "country" profile %}
                 </div>
 
                 {% if profile.regional_building %}

--- a/src/peoplefinder/templatetags/profile.py
+++ b/src/peoplefinder/templatetags/profile.py
@@ -21,7 +21,7 @@ def profile_field_anchor(profile, *field_names) -> Union[SafeString, str]:
 
 
 @register.inclusion_tag("peoplefinder/partials/profile-completion-field-link.html")
-def profile_completion_field_link(field_name, profile) -> Union[SafeString, str]:
+def profile_completion_field_actions(field_name, profile) -> Union[SafeString, str]:
     human_readable_field_name = field_name.replace("_", " ")
     if profile_field := Person._meta.get_field(field_name):
         human_readable_field_name = profile_field.verbose_name


### PR DESCRIPTION
This PR fixes the issue that Nico spotted with the Profile page summary, where it is wrapping a long email.
It's because there is an empty actions div.