### PR TITLE
DBTP-480 Infosec 9.4: Password found in configuration file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -105,3 +105,6 @@ UK_STAFF_LOCATIONS_DATABASE_URL=psql://postgres:postgres@db:5432/uk_staff_locati
 HIDE_NEWS=False
 
 FEEDBACK_NOTIFICATION_EMAIL_RECIPIENTS="marcel.kornblum@digital.trade.gov.uk,"
+
+# Variables used locally by docker-compose.yml
+DOCKER_COMPOSE_POSTGRES_PASSWORD=postgres

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ common/CACHE
 __pycache__
 !.gitignore
 .venv/
+venv
 .pytest_cache/
 .python-version
 .ruff_cache

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - ./.db:/var/lib/postgresql/data
     environment:
       - POSTGRES_DB=digital_workspace
-      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_PASSWORD=${DOCKER_COMPOSE_POSTGRES_PASSWORD}
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U postgres" ]
       interval: 5s


### PR DESCRIPTION
[Ticket ](https://uktrade.atlassian.net/browse/DBTP-480) arises from recent pen test of new DBT PaaS. Hardcoded variable in docker-compose.yml was identified as a potential security risk, even though it's currently only used in local dev workflow.

N.B. I had to add [an env variable](https://app.circleci.com/settings/project/github/uktrade/digital-workspace-v2/environment-variables?return-to=https%3A%2F%2Fapp.circleci.com%2Fpipelines%2Fgithub%2Fuktrade%2Fdigital-workspace-v2%3Fbranch%3DDPTP-480-Infosec-9.4-Password-found-in-configuration-file) in circle ci, in order to avoid hardcoding the password

