### PR TITLE
set DLFA_INCLUDE_RAW_LOG to True

### DIFF
--- a/src/config/settings/base.py
+++ b/src/config/settings/base.py
@@ -581,6 +581,8 @@ LOGGING = {
 if is_copilot():
     LOGGING["handlers"]["ecs"]["formatter"] = "asim_formatter"
 
+DLFA_INCLUDE_RAW_LOG = True
+
 # Remove SSO protection from health check and Hawk authed URLs
 AUTHBROKER_ANONYMOUS_PATHS = (
     "/pingdom/ping.xml",


### PR DESCRIPTION
Currently the original log output is being lost in ASIM format. Most of the output from `django_audit_log_middleware`, for instance, is being lost