### PR TITLE
Update the index schema to make sure it doesn't break search

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-web: cd src && python manage.py migrate --noinput && python manage.py collectstatic --noinput && opentelemetry-instrument waitress-serve --port=$PORT --threads=6 config.wsgi:application
+web: cd src && python manage.py migrate --noinput && python manage.py collectstatic --noinput && python manage.py update_index --schema-only && opentelemetry-instrument waitress-serve --port=$PORT --threads=6 config.wsgi:application
 beat: cd src && celery -A config.celery beat -l INFO
 worker: cd src && celery -A config.celery worker -l INFO


### PR DESCRIPTION
Running `update_index --schema-only` will update the index schema and result in search not 500'ing.
An `update_index` will still be needed if field names have changes/been added.