### PR TITLE
Hide GTM datalayer output in preview

### DIFF
--- a/src/core/templates/base.html
+++ b/src/core/templates/base.html
@@ -45,7 +45,9 @@
                 return false;
             };
             </script>
-            {% include "includes/gtm_datalayer_info.html" %}
+            {% if not request.is_preview %}
+                {% include "includes/gtm_datalayer_info.html" %}
+            {% endif %}
             <!-- End Google Tag Manager -->
         {% endif %}
         <link rel="shortcut icon"


### PR DESCRIPTION
We are seeing an influx of errors because the GTM Datalayer code is being used at Wagtail page preview time. And the GTM DL code is trying to get a list of all Topic titles. However, it is failing due to the way that querysets work at preview time.

We could dig a little deeper and fix the code so that it works in this scenario, but it begs the question:
**Should we be pushing to the Datalayer when an editor is previewing a page in the Wagtail admin?**

My initial feeling is that we shouldn't (hence this PR)