### PR TITLE
Convert to list comprehension to appease modelcluster

### DIFF
--- a/src/content/models.py
+++ b/src/content/models.py
@@ -284,7 +284,8 @@ class ContentPage(BasePage):
     def topics(self):
         from working_at_dit.models import Topic
 
-        topic_ids = self.page_topics.all().values_list("topic__pk", flat=True)
+        # This needs to be a list comprehension to work nicely with modelcluster.
+        topic_ids = [page_topic.topic.pk for page_topic in self.page_topics.all()]
         return Topic.objects.filter(pk__in=topic_ids)
 
     @property


### PR DESCRIPTION
Modelcluster doesn't play well with values_list, so @SamDudley suggested we just do a simple list comprehension.

- [x] Title is clear and concise
- [x] Description gives any relevant detail
- [x] Tests are up to date
- [x] Documentation is up to date
