### PR TITLE
Update the link list styling to use all of the available space

### DIFF
--- a/src/dw_design_system/dwds/components/link_list.scss
+++ b/src/dw_design_system/dwds/components/link_list.scss
@@ -9,6 +9,7 @@
         list-style-type: none;
         margin: 0;
         padding: 0;
+        max-inline-size: 100%;
         column-width: 25ch;
     }
 


### PR DESCRIPTION
Override the max inline size for the UL so that we can use all of the space
