### PR TITLE
Improve index update

### DIFF
--- a/src/core/management/commands/update_index_async.py
+++ b/src/core/management/commands/update_index_async.py
@@ -1,4 +1,6 @@
+from django.core.cache import cache
 from django.core.management.base import BaseCommand
+from wagtail.search.management.commands.update_index import Command
 
 
 class Command(BaseCommand):
@@ -7,8 +9,41 @@ class Command(BaseCommand):
         " command"
     )
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--force",
+            help="Force the update of the search index",
+            dest="force",
+            default=False,
+        )
+
     def handle(self, *args, **options):
         from core.tasks import update_search_index
+        from extended_search.management.commands.create_index_mapping_json import (
+            get_indexed_mapping_dict,
+        )
+
+        force = options["force"]
+        perform_update = force
+
+        if not force:
+            # Get the current search mapping hash
+            sm_hash = cache.get("search_mapping_hash")
+
+            # Get the search mapping dict
+            sm_dict = get_indexed_mapping_dict()
+            # Get the hash of the current search mapping dict
+            new_sm_hash = hash(frozenset(sm_dict.items()))
+
+            # If the hash of the current search mapping dict is different from the
+            # hash of the search mapping dict that was stored in the cache, then
+            # update the search index.
+            if sm_hash != new_sm_hash:
+                cache.set("search_mapping_hash", new_sm_hash)
+                perform_update = True
+
+        if not perform_update:
+            return
 
         update_search_index.delay()
 

--- a/src/core/management/commands/update_index_async.py
+++ b/src/core/management/commands/update_index_async.py
@@ -1,6 +1,5 @@
 from django.core.cache import cache
 from django.core.management.base import BaseCommand
-from wagtail.search.management.commands.update_index import Command
 
 
 class Command(BaseCommand):

--- a/src/core/tasks.py
+++ b/src/core/tasks.py
@@ -28,10 +28,6 @@ def ingest_uk_staff_locations(self):
 
 @celery_app.task(bind=True)
 def update_search_index(self):
-    # Run update_index --schema-only
-    call_command("update_index", schema_only=True)
-
-    # Run update_index
     call_command("update_index")
 
 

--- a/src/extended_search/management/commands/create_index_mapping_json.py
+++ b/src/extended_search/management/commands/create_index_mapping_json.py
@@ -1,10 +1,7 @@
 from pathlib import Path
 
 from django.core.management.base import BaseCommand
-from wagtail.documents.models import Document
-from wagtail.images.models import Image
 from wagtail.search.backends import get_search_backend
-from wagtailmedia.models import Media
 
 from extended_search.index import get_indexed_models
 

--- a/src/extended_search/management/commands/create_index_mapping_json.py
+++ b/src/extended_search/management/commands/create_index_mapping_json.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+from django.core.management.base import BaseCommand
+from wagtail.search.backends import get_search_backend
+
+from extended_search.index import get_indexed_models
+
+
+# Path: src/extended_search/management/commands/create_index_fields_json.py
+JSON_FILE = Path(__file__).parent / "indexed_mapping.json"
+
+
+def get_indexed_mapping_dict():
+    """
+    Return a dictionary of indexed models and their fields
+    Ignoring some models that we don't care about.
+    """
+
+    search_backend = get_search_backend()
+
+    return {
+        str(model): search_backend.mapping_class(model).get_mapping()
+        for model in get_indexed_models()
+    }
+
+
+class Command(BaseCommand):
+    help = "Create test JSON containing the mapping for all indexed models"
+
+    def handle(self, *args, **options):
+        import json
+
+        with open(JSON_FILE, "w") as f:
+            json.dump(get_indexed_mapping_dict(), f, indent=4)

--- a/src/extended_search/management/commands/create_index_mapping_json.py
+++ b/src/extended_search/management/commands/create_index_mapping_json.py
@@ -1,7 +1,10 @@
 from pathlib import Path
 
 from django.core.management.base import BaseCommand
+from wagtail.documents.models import Document
+from wagtail.images.models import Image
 from wagtail.search.backends import get_search_backend
+from wagtailmedia.models import Media
 
 from extended_search.index import get_indexed_models
 
@@ -10,17 +13,33 @@ from extended_search.index import get_indexed_models
 JSON_FILE = Path(__file__).parent / "indexed_mapping.json"
 
 
+def get_sorted_mapping(search_backend, model):
+    mapping = search_backend.mapping_class(model).get_mapping()
+
+    def sort_dict(d):
+        sorted_dict = dict(sorted(d.items()))
+        for k, v in d.items():
+            if isinstance(v, dict):
+                sorted_dict[k] = sort_dict(v)
+            else:
+                sorted_dict[k] = v
+        return sorted_dict
+
+    return sort_dict(mapping)
+
+
 def get_indexed_mapping_dict():
     """
     Return a dictionary of indexed models and their fields
     Ignoring some models that we don't care about.
     """
-
     search_backend = get_search_backend()
 
     return {
-        str(model): search_backend.mapping_class(model).get_mapping()
+        str(model): get_sorted_mapping(search_backend, model)
         for model in get_indexed_models()
+        # if model not in [Media, Document, Image]
+        if model._meta.app_label != "testapp"
     }
 
 

--- a/src/extended_search/management/commands/indexed_mapping.json
+++ b/src/extended_search/management/commands/indexed_mapping.json
@@ -1,94 +1,66 @@
 {
     "<class 'core.models.tags.Tag'>": {
         "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
-            },
-            "content_type": {
-                "type": "keyword"
-            },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "name": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "name_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
             "_all_text": {
                 "type": "text"
             },
             "_all_text_boost_1_0": {
                 "type": "text"
+            },
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "name": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "name_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "pk": {
+                "store": true,
+                "type": "keyword"
             }
         }
     },
     "<class 'home.models.HomePage'>": {
         "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            },
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
             },
             "content_type": {
                 "type": "keyword"
             },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title": {
-                "type": "text",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "title_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title_filter": {
-                "type": "keyword"
-            },
-            "id_filter": {
-                "type": "integer"
-            },
-            "live_filter": {
-                "type": "boolean"
-            },
-            "owner_id_filter": {
-                "type": "integer"
-            },
             "content_type_id_filter": {
                 "type": "integer"
-            },
-            "path_filter": {
-                "type": "keyword"
             },
             "depth_filter": {
                 "type": "integer"
             },
-            "locked_filter": {
-                "type": "boolean"
-            },
-            "show_in_menus_filter": {
-                "type": "boolean"
-            },
             "first_published_at_filter": {
                 "type": "date"
+            },
+            "id_filter": {
+                "type": "integer"
             },
             "last_published_at_filter": {
                 "type": "date"
@@ -96,75 +68,75 @@
             "latest_revision_created_at_filter": {
                 "type": "date"
             },
+            "live_filter": {
+                "type": "boolean"
+            },
             "locale_id_filter": {
                 "type": "integer"
             },
-            "translation_key_filter": {
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
                 "type": "keyword"
             },
-            "_all_text": {
+            "pk": {
+                "store": true,
+                "type": "keyword"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "title": {
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
                 "type": "text"
             },
-            "_all_text_boost_2_0": {
+            "title_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
                 "type": "text"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
             }
         }
     },
     "<class 'content.models.BasePage'>": {
         "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            },
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
             },
             "content_type": {
                 "type": "keyword"
             },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title": {
-                "type": "text",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "title_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title_filter": {
-                "type": "keyword"
-            },
-            "id_filter": {
-                "type": "integer"
-            },
-            "live_filter": {
-                "type": "boolean"
-            },
-            "owner_id_filter": {
-                "type": "integer"
-            },
             "content_type_id_filter": {
                 "type": "integer"
-            },
-            "path_filter": {
-                "type": "keyword"
             },
             "depth_filter": {
                 "type": "integer"
             },
-            "locked_filter": {
-                "type": "boolean"
-            },
-            "show_in_menus_filter": {
-                "type": "boolean"
-            },
             "first_published_at_filter": {
                 "type": "date"
+            },
+            "id_filter": {
+                "type": "integer"
             },
             "last_published_at_filter": {
                 "type": "date"
@@ -172,155 +144,50 @@
             "latest_revision_created_at_filter": {
                 "type": "date"
             },
+            "live_filter": {
+                "type": "boolean"
+            },
             "locale_id_filter": {
                 "type": "integer"
             },
-            "translation_key_filter": {
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
                 "type": "keyword"
             },
-            "_all_text": {
+            "pk": {
+                "store": true,
+                "type": "keyword"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "title": {
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
                 "type": "text"
             },
-            "_all_text_boost_2_0": {
+            "title_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
                 "type": "text"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
             }
         }
     },
     "<class 'content.models.ContentPage'>": {
         "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
-            },
-            "content_type": {
-                "type": "keyword"
-            },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title": {
-                "type": "text",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "title_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title_filter": {
-                "type": "keyword"
-            },
-            "id_filter": {
-                "type": "integer"
-            },
-            "live_filter": {
-                "type": "boolean"
-            },
-            "owner_id_filter": {
-                "type": "integer"
-            },
-            "content_type_id_filter": {
-                "type": "integer"
-            },
-            "path_filter": {
-                "type": "keyword"
-            },
-            "depth_filter": {
-                "type": "integer"
-            },
-            "locked_filter": {
-                "type": "boolean"
-            },
-            "show_in_menus_filter": {
-                "type": "boolean"
-            },
-            "first_published_at_filter": {
-                "type": "date"
-            },
-            "last_published_at_filter": {
-                "type": "date"
-            },
-            "latest_revision_created_at_filter": {
-                "type": "date"
-            },
-            "locale_id_filter": {
-                "type": "integer"
-            },
-            "translation_key_filter": {
-                "type": "keyword"
-            },
-            "content_contentpage__search_title_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "content_contentpage__search_title": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "content_contentpage__search_headings_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "content_contentpage__search_headings": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "content_contentpage__search_content_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "content_contentpage__search_content": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "content_contentpage__excerpt_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "content_contentpage__excerpt": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "content_contentpage__is_creatable_filter": {
-                "type": "keyword"
-            },
             "_all_text": {
                 "type": "text"
             },
@@ -335,125 +202,144 @@
             },
             "_all_text_boost_5_0": {
                 "type": "text"
+            },
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "content_contentpage__excerpt": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__excerpt_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "content_contentpage__search_content": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_content_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_headings": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_headings_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_title": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_title_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "pk": {
+                "store": true,
+                "type": "keyword"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "title": {
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "title_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
             }
         }
     },
     "<class 'content.models.NavigationPage'>": {
         "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
-            },
-            "content_type": {
-                "type": "keyword"
-            },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title": {
-                "type": "text",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "title_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title_filter": {
-                "type": "keyword"
-            },
-            "id_filter": {
-                "type": "integer"
-            },
-            "live_filter": {
-                "type": "boolean"
-            },
-            "owner_id_filter": {
-                "type": "integer"
-            },
-            "content_type_id_filter": {
-                "type": "integer"
-            },
-            "path_filter": {
-                "type": "keyword"
-            },
-            "depth_filter": {
-                "type": "integer"
-            },
-            "locked_filter": {
-                "type": "boolean"
-            },
-            "show_in_menus_filter": {
-                "type": "boolean"
-            },
-            "first_published_at_filter": {
-                "type": "date"
-            },
-            "last_published_at_filter": {
-                "type": "date"
-            },
-            "latest_revision_created_at_filter": {
-                "type": "date"
-            },
-            "locale_id_filter": {
-                "type": "integer"
-            },
-            "translation_key_filter": {
-                "type": "keyword"
-            },
-            "content_navigationpage__search_title_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "content_navigationpage__search_title": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "content_navigationpage__search_headings_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "content_navigationpage__search_headings": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "content_navigationpage__search_content_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "content_navigationpage__search_content": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
             "_all_text": {
                 "type": "text"
             },
@@ -468,64 +354,150 @@
             },
             "_all_text_boost_5_0": {
                 "type": "text"
+            },
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "content_navigationpage__search_content": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "content_navigationpage__search_content_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "content_navigationpage__search_headings": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "content_navigationpage__search_headings_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "content_navigationpage__search_title": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "content_navigationpage__search_title_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "pk": {
+                "store": true,
+                "type": "keyword"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "title": {
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "title_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
             }
         }
     },
     "<class 'content.models.BlogIndex'>": {
         "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            },
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
             },
             "content_type": {
                 "type": "keyword"
             },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title": {
-                "type": "text",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "title_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title_filter": {
-                "type": "keyword"
-            },
-            "id_filter": {
-                "type": "integer"
-            },
-            "live_filter": {
-                "type": "boolean"
-            },
-            "owner_id_filter": {
-                "type": "integer"
-            },
             "content_type_id_filter": {
                 "type": "integer"
-            },
-            "path_filter": {
-                "type": "keyword"
             },
             "depth_filter": {
                 "type": "integer"
             },
-            "locked_filter": {
-                "type": "boolean"
-            },
-            "show_in_menus_filter": {
-                "type": "boolean"
-            },
             "first_published_at_filter": {
                 "type": "date"
+            },
+            "id_filter": {
+                "type": "integer"
             },
             "last_published_at_filter": {
                 "type": "date"
@@ -533,75 +505,151 @@
             "latest_revision_created_at_filter": {
                 "type": "date"
             },
+            "live_filter": {
+                "type": "boolean"
+            },
             "locale_id_filter": {
                 "type": "integer"
             },
-            "translation_key_filter": {
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
                 "type": "keyword"
             },
-            "_all_text": {
+            "pk": {
+                "store": true,
+                "type": "keyword"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "title": {
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
                 "type": "text"
             },
-            "_all_text_boost_2_0": {
+            "title_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
                 "type": "text"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
             }
         }
     },
     "<class 'content.models.BlogPost'>": {
         "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_1_0": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            },
+            "_all_text_boost_3_0": {
+                "type": "text"
+            },
+            "_all_text_boost_5_0": {
+                "type": "text"
+            },
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "content_blogpost__excerpt": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "content_blogpost__excerpt_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "content_blogpost__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "content_blogpost__search_content": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "content_blogpost__search_content_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "content_blogpost__search_headings": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "content_blogpost__search_headings_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "content_blogpost__search_title": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "content_blogpost__search_title_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
             },
             "content_type": {
                 "type": "keyword"
             },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title": {
-                "type": "text",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "title_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title_filter": {
-                "type": "keyword"
-            },
-            "id_filter": {
-                "type": "integer"
-            },
-            "live_filter": {
-                "type": "boolean"
-            },
-            "owner_id_filter": {
-                "type": "integer"
-            },
             "content_type_id_filter": {
                 "type": "integer"
-            },
-            "path_filter": {
-                "type": "keyword"
             },
             "depth_filter": {
                 "type": "integer"
             },
-            "locked_filter": {
-                "type": "boolean"
-            },
-            "show_in_menus_filter": {
-                "type": "boolean"
-            },
             "first_published_at_filter": {
                 "type": "date"
+            },
+            "id_filter": {
+                "type": "integer"
             },
             "last_published_at_filter": {
                 "type": "date"
@@ -609,263 +657,50 @@
             "latest_revision_created_at_filter": {
                 "type": "date"
             },
-            "locale_id_filter": {
-                "type": "integer"
-            },
-            "translation_key_filter": {
-                "type": "keyword"
-            },
-            "content_blogpost__search_title_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "content_blogpost__search_title": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "content_blogpost__search_headings_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "content_blogpost__search_headings": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "content_blogpost__search_content_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "content_blogpost__search_content": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "content_blogpost__excerpt_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "content_blogpost__excerpt": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "content_blogpost__is_creatable_filter": {
-                "type": "keyword"
-            },
-            "_all_text": {
-                "type": "text"
-            },
-            "_all_text_boost_1_0": {
-                "type": "text"
-            },
-            "_all_text_boost_2_0": {
-                "type": "text"
-            },
-            "_all_text_boost_3_0": {
-                "type": "text"
-            },
-            "_all_text_boost_5_0": {
-                "type": "text"
-            }
-        }
-    },
-    "<class 'news.models.NewsPage'>": {
-        "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
-            },
-            "content_type": {
-                "type": "keyword"
-            },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title": {
-                "type": "text",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "title_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title_filter": {
-                "type": "keyword"
-            },
-            "id_filter": {
-                "type": "integer"
-            },
             "live_filter": {
                 "type": "boolean"
             },
-            "owner_id_filter": {
-                "type": "integer"
-            },
-            "content_type_id_filter": {
-                "type": "integer"
-            },
-            "path_filter": {
-                "type": "keyword"
-            },
-            "depth_filter": {
+            "locale_id_filter": {
                 "type": "integer"
             },
             "locked_filter": {
                 "type": "boolean"
             },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "pk": {
+                "store": true,
+                "type": "keyword"
+            },
             "show_in_menus_filter": {
                 "type": "boolean"
             },
-            "first_published_at_filter": {
-                "type": "date"
+            "title": {
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
             },
-            "news_newspage__last_published_at_scorefunction_filter": {
-                "type": "date"
+            "title_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
             },
-            "latest_revision_created_at_filter": {
-                "type": "date"
-            },
-            "locale_id_filter": {
-                "type": "integer"
+            "title_filter": {
+                "type": "keyword"
             },
             "translation_key_filter": {
                 "type": "keyword"
-            },
-            "content_contentpage__search_title_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "content_contentpage__search_title": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "content_contentpage__search_headings_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "content_contentpage__search_headings": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "content_contentpage__search_content_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "content_contentpage__search_content": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "content_contentpage__excerpt_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "content_contentpage__excerpt": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "content_contentpage__is_creatable_filter": {
-                "type": "keyword"
-            },
-            "working_at_dit_pagewithtopics__topic_titles_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "working_at_dit_pagewithtopics__topic_titles": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "news_newspage__search_categories": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "news_newspage__search_categories_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "news_newspage__pinned_on_home_filter": {
-                "type": "boolean"
-            },
+            }
+        }
+    },
+    "<class 'news.models.NewsPage'>": {
+        "properties": {
             "_all_text": {
                 "type": "text"
             },
@@ -879,141 +714,202 @@
                 "type": "text"
             },
             "_all_text_boost_5_0": {
+                "type": "text"
+            },
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "content_contentpage__excerpt": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__excerpt_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "content_contentpage__search_content": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_content_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_headings": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_headings_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_title": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_title_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "news_newspage__last_published_at_scorefunction_filter": {
+                "type": "date"
+            },
+            "news_newspage__pinned_on_home_filter": {
+                "type": "boolean"
+            },
+            "news_newspage__search_categories": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "news_newspage__search_categories_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "pk": {
+                "store": true,
+                "type": "keyword"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "title": {
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "title_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "working_at_dit_pagewithtopics__topic_titles": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "working_at_dit_pagewithtopics__topic_titles_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
                 "type": "text"
             }
         }
     },
     "<class 'news.models.NewsHome'>": {
         "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
-            },
-            "content_type": {
-                "type": "keyword"
-            },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title": {
-                "type": "text",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "title_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title_filter": {
-                "type": "keyword"
-            },
-            "id_filter": {
-                "type": "integer"
-            },
-            "live_filter": {
-                "type": "boolean"
-            },
-            "owner_id_filter": {
-                "type": "integer"
-            },
-            "content_type_id_filter": {
-                "type": "integer"
-            },
-            "path_filter": {
-                "type": "keyword"
-            },
-            "depth_filter": {
-                "type": "integer"
-            },
-            "locked_filter": {
-                "type": "boolean"
-            },
-            "show_in_menus_filter": {
-                "type": "boolean"
-            },
-            "first_published_at_filter": {
-                "type": "date"
-            },
-            "last_published_at_filter": {
-                "type": "date"
-            },
-            "latest_revision_created_at_filter": {
-                "type": "date"
-            },
-            "locale_id_filter": {
-                "type": "integer"
-            },
-            "translation_key_filter": {
-                "type": "keyword"
-            },
             "_all_text": {
                 "type": "text"
             },
             "_all_text_boost_2_0": {
                 "type": "text"
-            }
-        }
-    },
-    "<class 'working_at_dit.models.WorkingAtDITHome'>": {
-        "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
+            },
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
             },
             "content_type": {
                 "type": "keyword"
             },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title": {
-                "type": "text",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "title_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title_filter": {
-                "type": "keyword"
-            },
-            "id_filter": {
-                "type": "integer"
-            },
-            "live_filter": {
-                "type": "boolean"
-            },
-            "owner_id_filter": {
-                "type": "integer"
-            },
             "content_type_id_filter": {
                 "type": "integer"
-            },
-            "path_filter": {
-                "type": "keyword"
             },
             "depth_filter": {
                 "type": "integer"
             },
-            "locked_filter": {
-                "type": "boolean"
-            },
-            "show_in_menus_filter": {
-                "type": "boolean"
-            },
             "first_published_at_filter": {
                 "type": "date"
+            },
+            "id_filter": {
+                "type": "integer"
             },
             "last_published_at_filter": {
                 "type": "date"
@@ -1021,79 +917,50 @@
             "latest_revision_created_at_filter": {
                 "type": "date"
             },
+            "live_filter": {
+                "type": "boolean"
+            },
             "locale_id_filter": {
                 "type": "integer"
             },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "pk": {
+                "store": true,
+                "type": "keyword"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "title": {
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "title_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
             "translation_key_filter": {
                 "type": "keyword"
-            },
-            "working_at_dit_workingatdithome__search_title_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "working_at_dit_workingatdithome__search_title": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "working_at_dit_workingatdithome__search_headings_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "working_at_dit_workingatdithome__search_headings": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "working_at_dit_workingatdithome__search_content_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "working_at_dit_workingatdithome__search_content": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "working_at_dit_workingatdithome__excerpt_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "working_at_dit_workingatdithome__excerpt": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "working_at_dit_workingatdithome__is_creatable_filter": {
-                "type": "keyword"
-            },
+            }
+        }
+    },
+    "<class 'working_at_dit.models.WorkingAtDITHome'>": {
+        "properties": {
             "_all_text": {
                 "type": "text"
             },
@@ -1107,182 +974,145 @@
                 "type": "text"
             },
             "_all_text_boost_5_0": {
+                "type": "text"
+            },
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "pk": {
+                "store": true,
+                "type": "keyword"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "title": {
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "title_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "working_at_dit_workingatdithome__excerpt": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "working_at_dit_workingatdithome__excerpt_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "working_at_dit_workingatdithome__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "working_at_dit_workingatdithome__search_content": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "working_at_dit_workingatdithome__search_content_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "working_at_dit_workingatdithome__search_headings": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "working_at_dit_workingatdithome__search_headings_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "working_at_dit_workingatdithome__search_title": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "working_at_dit_workingatdithome__search_title_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
                 "type": "text"
             }
         }
     },
     "<class 'working_at_dit.models.Topic'>": {
         "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
-            },
-            "content_type": {
-                "type": "keyword"
-            },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title": {
-                "type": "text",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "title_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title_filter": {
-                "type": "keyword"
-            },
-            "id_filter": {
-                "type": "integer"
-            },
-            "live_filter": {
-                "type": "boolean"
-            },
-            "owner_id_filter": {
-                "type": "integer"
-            },
-            "content_type_id_filter": {
-                "type": "integer"
-            },
-            "path_filter": {
-                "type": "keyword"
-            },
-            "depth_filter": {
-                "type": "integer"
-            },
-            "locked_filter": {
-                "type": "boolean"
-            },
-            "show_in_menus_filter": {
-                "type": "boolean"
-            },
-            "first_published_at_filter": {
-                "type": "date"
-            },
-            "last_published_at_filter": {
-                "type": "date"
-            },
-            "latest_revision_created_at_filter": {
-                "type": "date"
-            },
-            "locale_id_filter": {
-                "type": "integer"
-            },
-            "translation_key_filter": {
-                "type": "keyword"
-            },
-            "content_contentpage__search_title_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "content_contentpage__search_title": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "content_contentpage__search_headings_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "content_contentpage__search_headings": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "content_contentpage__search_content_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "content_contentpage__search_content": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "content_contentpage__excerpt_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "content_contentpage__excerpt": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "content_contentpage__is_creatable_filter": {
-                "type": "keyword"
-            },
-            "working_at_dit_topic__content_owner": {
-                "type": "nested",
-                "properties": {
-                    "working_at_dit_topic__first_name_explicit": {
-                        "type": "text",
-                        "analyzer": "simple",
-                        "copy_to": [
-                            "_all_text",
-                            "_all_text_boost_1_0"
-                        ]
-                    },
-                    "working_at_dit_topic__preferred_first_name_explicit": {
-                        "type": "text",
-                        "analyzer": "simple",
-                        "copy_to": [
-                            "_all_text",
-                            "_all_text_boost_1_0"
-                        ]
-                    },
-                    "working_at_dit_topic__last_name_explicit": {
-                        "type": "text",
-                        "analyzer": "simple",
-                        "copy_to": [
-                            "_all_text",
-                            "_all_text_boost_1_0"
-                        ]
-                    }
-                }
-            },
-            "working_at_dit_topic__content_contact_email_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
             "_all_text": {
                 "type": "text"
             },
@@ -1297,140 +1127,206 @@
             },
             "_all_text_boost_5_0": {
                 "type": "text"
+            },
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "content_contentpage__excerpt": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__excerpt_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "content_contentpage__search_content": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_content_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_headings": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_headings_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_title": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_title_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "pk": {
+                "store": true,
+                "type": "keyword"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "title": {
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "title_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "working_at_dit_topic__content_contact_email_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "working_at_dit_topic__content_owner": {
+                "properties": {
+                    "working_at_dit_topic__first_name_explicit": {
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_0"
+                        ],
+                        "type": "text"
+                    },
+                    "working_at_dit_topic__last_name_explicit": {
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_0"
+                        ],
+                        "type": "text"
+                    },
+                    "working_at_dit_topic__preferred_first_name_explicit": {
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_0"
+                        ],
+                        "type": "text"
+                    }
+                },
+                "type": "nested"
             }
         }
     },
     "<class 'working_at_dit.models.TopicHome'>": {
         "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
-            },
-            "content_type": {
-                "type": "keyword"
-            },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title": {
-                "type": "text",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "title_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title_filter": {
-                "type": "keyword"
-            },
-            "id_filter": {
-                "type": "integer"
-            },
-            "live_filter": {
-                "type": "boolean"
-            },
-            "owner_id_filter": {
-                "type": "integer"
-            },
-            "content_type_id_filter": {
-                "type": "integer"
-            },
-            "path_filter": {
-                "type": "keyword"
-            },
-            "depth_filter": {
-                "type": "integer"
-            },
-            "locked_filter": {
-                "type": "boolean"
-            },
-            "show_in_menus_filter": {
-                "type": "boolean"
-            },
-            "first_published_at_filter": {
-                "type": "date"
-            },
-            "last_published_at_filter": {
-                "type": "date"
-            },
-            "latest_revision_created_at_filter": {
-                "type": "date"
-            },
-            "locale_id_filter": {
-                "type": "integer"
-            },
-            "translation_key_filter": {
-                "type": "keyword"
-            },
             "_all_text": {
                 "type": "text"
             },
             "_all_text_boost_2_0": {
                 "type": "text"
-            }
-        }
-    },
-    "<class 'working_at_dit.models.PageWithTopics'>": {
-        "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
+            },
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
             },
             "content_type": {
                 "type": "keyword"
             },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title": {
-                "type": "text",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "title_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title_filter": {
-                "type": "keyword"
-            },
-            "id_filter": {
-                "type": "integer"
-            },
-            "live_filter": {
-                "type": "boolean"
-            },
-            "owner_id_filter": {
-                "type": "integer"
-            },
             "content_type_id_filter": {
                 "type": "integer"
-            },
-            "path_filter": {
-                "type": "keyword"
             },
             "depth_filter": {
                 "type": "integer"
             },
-            "locked_filter": {
-                "type": "boolean"
-            },
-            "show_in_menus_filter": {
-                "type": "boolean"
-            },
             "first_published_at_filter": {
                 "type": "date"
+            },
+            "id_filter": {
+                "type": "integer"
             },
             "last_published_at_filter": {
                 "type": "date"
@@ -1438,95 +1334,50 @@
             "latest_revision_created_at_filter": {
                 "type": "date"
             },
+            "live_filter": {
+                "type": "boolean"
+            },
             "locale_id_filter": {
                 "type": "integer"
             },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "pk": {
+                "store": true,
+                "type": "keyword"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "title": {
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "title_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
             "translation_key_filter": {
                 "type": "keyword"
-            },
-            "content_contentpage__search_title_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "content_contentpage__search_title": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "content_contentpage__search_headings_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "content_contentpage__search_headings": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "content_contentpage__search_content_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "content_contentpage__search_content": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "content_contentpage__excerpt_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "content_contentpage__excerpt": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "content_contentpage__is_creatable_filter": {
-                "type": "keyword"
-            },
-            "working_at_dit_pagewithtopics__topic_titles_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "working_at_dit_pagewithtopics__topic_titles": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
+            }
+        }
+    },
+    "<class 'working_at_dit.models.PageWithTopics'>": {
+        "properties": {
             "_all_text": {
                 "type": "text"
             },
@@ -1540,198 +1391,161 @@
                 "type": "text"
             },
             "_all_text_boost_5_0": {
+                "type": "text"
+            },
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "content_contentpage__excerpt": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__excerpt_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "content_contentpage__search_content": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_content_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_headings": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_headings_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_title": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_title_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "pk": {
+                "store": true,
+                "type": "keyword"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "title": {
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "title_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "working_at_dit_pagewithtopics__topic_titles": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "working_at_dit_pagewithtopics__topic_titles_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
                 "type": "text"
             }
         }
     },
     "<class 'working_at_dit.models.HowDoI'>": {
         "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
-            },
-            "content_type": {
-                "type": "keyword"
-            },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title": {
-                "type": "text",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "title_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title_filter": {
-                "type": "keyword"
-            },
-            "id_filter": {
-                "type": "integer"
-            },
-            "live_filter": {
-                "type": "boolean"
-            },
-            "owner_id_filter": {
-                "type": "integer"
-            },
-            "content_type_id_filter": {
-                "type": "integer"
-            },
-            "path_filter": {
-                "type": "keyword"
-            },
-            "depth_filter": {
-                "type": "integer"
-            },
-            "locked_filter": {
-                "type": "boolean"
-            },
-            "show_in_menus_filter": {
-                "type": "boolean"
-            },
-            "first_published_at_filter": {
-                "type": "date"
-            },
-            "last_published_at_filter": {
-                "type": "date"
-            },
-            "latest_revision_created_at_filter": {
-                "type": "date"
-            },
-            "locale_id_filter": {
-                "type": "integer"
-            },
-            "translation_key_filter": {
-                "type": "keyword"
-            },
-            "content_contentpage__search_title_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "content_contentpage__search_title": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "content_contentpage__search_headings_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "content_contentpage__search_headings": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "content_contentpage__search_content_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "content_contentpage__search_content": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "content_contentpage__excerpt_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "content_contentpage__excerpt": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "content_contentpage__is_creatable_filter": {
-                "type": "keyword"
-            },
-            "working_at_dit_pagewithtopics__topic_titles_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "working_at_dit_pagewithtopics__topic_titles": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "working_at_dit_howdoi__content_owner": {
-                "type": "nested",
-                "properties": {
-                    "working_at_dit_howdoi__first_name_explicit": {
-                        "type": "text",
-                        "analyzer": "simple",
-                        "copy_to": [
-                            "_all_text",
-                            "_all_text_boost_1_0"
-                        ]
-                    },
-                    "working_at_dit_howdoi__preferred_first_name_explicit": {
-                        "type": "text",
-                        "analyzer": "simple",
-                        "copy_to": [
-                            "_all_text",
-                            "_all_text_boost_1_0"
-                        ]
-                    },
-                    "working_at_dit_howdoi__last_name_explicit": {
-                        "type": "text",
-                        "analyzer": "simple",
-                        "copy_to": [
-                            "_all_text",
-                            "_all_text_boost_1_0"
-                        ]
-                    }
-                }
-            },
-            "working_at_dit_howdoi__content_contact_email_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
             "_all_text": {
                 "type": "text"
             },
@@ -1745,145 +1559,198 @@
                 "type": "text"
             },
             "_all_text_boost_5_0": {
+                "type": "text"
+            },
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "content_contentpage__excerpt": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__excerpt_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "content_contentpage__search_content": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_content_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_headings": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_headings_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_title": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_title_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "pk": {
+                "store": true,
+                "type": "keyword"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "title": {
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "title_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "working_at_dit_howdoi__content_contact_email_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "working_at_dit_howdoi__content_owner": {
+                "properties": {
+                    "working_at_dit_howdoi__first_name_explicit": {
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_0"
+                        ],
+                        "type": "text"
+                    },
+                    "working_at_dit_howdoi__last_name_explicit": {
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_0"
+                        ],
+                        "type": "text"
+                    },
+                    "working_at_dit_howdoi__preferred_first_name_explicit": {
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_0"
+                        ],
+                        "type": "text"
+                    }
+                },
+                "type": "nested"
+            },
+            "working_at_dit_pagewithtopics__topic_titles": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "working_at_dit_pagewithtopics__topic_titles_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
                 "type": "text"
             }
         }
     },
     "<class 'working_at_dit.models.HowDoIHome'>": {
         "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
-            },
-            "content_type": {
-                "type": "keyword"
-            },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title": {
-                "type": "text",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "title_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title_filter": {
-                "type": "keyword"
-            },
-            "id_filter": {
-                "type": "integer"
-            },
-            "live_filter": {
-                "type": "boolean"
-            },
-            "owner_id_filter": {
-                "type": "integer"
-            },
-            "content_type_id_filter": {
-                "type": "integer"
-            },
-            "path_filter": {
-                "type": "keyword"
-            },
-            "depth_filter": {
-                "type": "integer"
-            },
-            "locked_filter": {
-                "type": "boolean"
-            },
-            "show_in_menus_filter": {
-                "type": "boolean"
-            },
-            "first_published_at_filter": {
-                "type": "date"
-            },
-            "last_published_at_filter": {
-                "type": "date"
-            },
-            "latest_revision_created_at_filter": {
-                "type": "date"
-            },
-            "locale_id_filter": {
-                "type": "integer"
-            },
-            "translation_key_filter": {
-                "type": "keyword"
-            },
-            "working_at_dit_howdoihome__search_title_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "working_at_dit_howdoihome__search_title": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "working_at_dit_howdoihome__search_headings_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "working_at_dit_howdoihome__search_headings": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "working_at_dit_howdoihome__search_content_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "working_at_dit_howdoihome__search_content": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "working_at_dit_howdoihome__excerpt_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "working_at_dit_howdoihome__excerpt": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "working_at_dit_howdoihome__is_creatable_filter": {
-                "type": "keyword"
-            },
             "_all_text": {
                 "type": "text"
             },
@@ -1897,198 +1764,145 @@
                 "type": "text"
             },
             "_all_text_boost_5_0": {
+                "type": "text"
+            },
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "pk": {
+                "store": true,
+                "type": "keyword"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "title": {
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "title_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "working_at_dit_howdoihome__excerpt": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "working_at_dit_howdoihome__excerpt_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "working_at_dit_howdoihome__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "working_at_dit_howdoihome__search_content": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "working_at_dit_howdoihome__search_content_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "working_at_dit_howdoihome__search_headings": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "working_at_dit_howdoihome__search_headings_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "working_at_dit_howdoihome__search_title": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "working_at_dit_howdoihome__search_title_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
                 "type": "text"
             }
         }
     },
     "<class 'working_at_dit.models.Guidance'>": {
         "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
-            },
-            "content_type": {
-                "type": "keyword"
-            },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title": {
-                "type": "text",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "title_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title_filter": {
-                "type": "keyword"
-            },
-            "id_filter": {
-                "type": "integer"
-            },
-            "live_filter": {
-                "type": "boolean"
-            },
-            "owner_id_filter": {
-                "type": "integer"
-            },
-            "content_type_id_filter": {
-                "type": "integer"
-            },
-            "path_filter": {
-                "type": "keyword"
-            },
-            "depth_filter": {
-                "type": "integer"
-            },
-            "locked_filter": {
-                "type": "boolean"
-            },
-            "show_in_menus_filter": {
-                "type": "boolean"
-            },
-            "first_published_at_filter": {
-                "type": "date"
-            },
-            "last_published_at_filter": {
-                "type": "date"
-            },
-            "latest_revision_created_at_filter": {
-                "type": "date"
-            },
-            "locale_id_filter": {
-                "type": "integer"
-            },
-            "translation_key_filter": {
-                "type": "keyword"
-            },
-            "content_contentpage__search_title_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "content_contentpage__search_title": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "content_contentpage__search_headings_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "content_contentpage__search_headings": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "content_contentpage__search_content_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "content_contentpage__search_content": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "content_contentpage__excerpt_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "content_contentpage__excerpt": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "content_contentpage__is_creatable_filter": {
-                "type": "keyword"
-            },
-            "working_at_dit_pagewithtopics__topic_titles_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "working_at_dit_pagewithtopics__topic_titles": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "working_at_dit_guidance__content_owner": {
-                "type": "nested",
-                "properties": {
-                    "working_at_dit_guidance__first_name_explicit": {
-                        "type": "text",
-                        "analyzer": "simple",
-                        "copy_to": [
-                            "_all_text",
-                            "_all_text_boost_1_0"
-                        ]
-                    },
-                    "working_at_dit_guidance__preferred_first_name_explicit": {
-                        "type": "text",
-                        "analyzer": "simple",
-                        "copy_to": [
-                            "_all_text",
-                            "_all_text_boost_1_0"
-                        ]
-                    },
-                    "working_at_dit_guidance__last_name_explicit": {
-                        "type": "text",
-                        "analyzer": "simple",
-                        "copy_to": [
-                            "_all_text",
-                            "_all_text_boost_1_0"
-                        ]
-                    }
-                }
-            },
-            "working_at_dit_guidance__content_contact_email_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
             "_all_text": {
                 "type": "text"
             },
@@ -2102,198 +1916,198 @@
                 "type": "text"
             },
             "_all_text_boost_5_0": {
+                "type": "text"
+            },
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "content_contentpage__excerpt": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__excerpt_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "content_contentpage__search_content": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_content_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_headings": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_headings_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_title": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_title_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "pk": {
+                "store": true,
+                "type": "keyword"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "title": {
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "title_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "working_at_dit_guidance__content_contact_email_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "working_at_dit_guidance__content_owner": {
+                "properties": {
+                    "working_at_dit_guidance__first_name_explicit": {
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_0"
+                        ],
+                        "type": "text"
+                    },
+                    "working_at_dit_guidance__last_name_explicit": {
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_0"
+                        ],
+                        "type": "text"
+                    },
+                    "working_at_dit_guidance__preferred_first_name_explicit": {
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_0"
+                        ],
+                        "type": "text"
+                    }
+                },
+                "type": "nested"
+            },
+            "working_at_dit_pagewithtopics__topic_titles": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "working_at_dit_pagewithtopics__topic_titles_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
                 "type": "text"
             }
         }
     },
     "<class 'working_at_dit.models.Policy'>": {
         "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
-            },
-            "content_type": {
-                "type": "keyword"
-            },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title": {
-                "type": "text",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "title_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title_filter": {
-                "type": "keyword"
-            },
-            "id_filter": {
-                "type": "integer"
-            },
-            "live_filter": {
-                "type": "boolean"
-            },
-            "owner_id_filter": {
-                "type": "integer"
-            },
-            "content_type_id_filter": {
-                "type": "integer"
-            },
-            "path_filter": {
-                "type": "keyword"
-            },
-            "depth_filter": {
-                "type": "integer"
-            },
-            "locked_filter": {
-                "type": "boolean"
-            },
-            "show_in_menus_filter": {
-                "type": "boolean"
-            },
-            "first_published_at_filter": {
-                "type": "date"
-            },
-            "last_published_at_filter": {
-                "type": "date"
-            },
-            "latest_revision_created_at_filter": {
-                "type": "date"
-            },
-            "locale_id_filter": {
-                "type": "integer"
-            },
-            "translation_key_filter": {
-                "type": "keyword"
-            },
-            "content_contentpage__search_title_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "content_contentpage__search_title": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "content_contentpage__search_headings_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "content_contentpage__search_headings": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "content_contentpage__search_content_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "content_contentpage__search_content": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "content_contentpage__excerpt_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "content_contentpage__excerpt": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "content_contentpage__is_creatable_filter": {
-                "type": "keyword"
-            },
-            "working_at_dit_pagewithtopics__topic_titles_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "working_at_dit_pagewithtopics__topic_titles": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "working_at_dit_policy__content_owner": {
-                "type": "nested",
-                "properties": {
-                    "working_at_dit_policy__first_name_explicit": {
-                        "type": "text",
-                        "analyzer": "simple",
-                        "copy_to": [
-                            "_all_text",
-                            "_all_text_boost_1_0"
-                        ]
-                    },
-                    "working_at_dit_policy__preferred_first_name_explicit": {
-                        "type": "text",
-                        "analyzer": "simple",
-                        "copy_to": [
-                            "_all_text",
-                            "_all_text_boost_1_0"
-                        ]
-                    },
-                    "working_at_dit_policy__last_name_explicit": {
-                        "type": "text",
-                        "analyzer": "simple",
-                        "copy_to": [
-                            "_all_text",
-                            "_all_text_boost_1_0"
-                        ]
-                    }
-                }
-            },
-            "working_at_dit_policy__content_contact_email_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
             "_all_text": {
                 "type": "text"
             },
@@ -2308,64 +2122,222 @@
             },
             "_all_text_boost_5_0": {
                 "type": "text"
+            },
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "content_contentpage__excerpt": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__excerpt_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "content_contentpage__search_content": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_content_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_headings": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_headings_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_title": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_title_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "pk": {
+                "store": true,
+                "type": "keyword"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "title": {
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "title_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "working_at_dit_pagewithtopics__topic_titles": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "working_at_dit_pagewithtopics__topic_titles_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "working_at_dit_policy__content_contact_email_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "working_at_dit_policy__content_owner": {
+                "properties": {
+                    "working_at_dit_policy__first_name_explicit": {
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_0"
+                        ],
+                        "type": "text"
+                    },
+                    "working_at_dit_policy__last_name_explicit": {
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_0"
+                        ],
+                        "type": "text"
+                    },
+                    "working_at_dit_policy__preferred_first_name_explicit": {
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_0"
+                        ],
+                        "type": "text"
+                    }
+                },
+                "type": "nested"
             }
         }
     },
     "<class 'working_at_dit.models.PoliciesHome'>": {
         "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            },
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
             },
             "content_type": {
                 "type": "keyword"
             },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title": {
-                "type": "text",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "title_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title_filter": {
-                "type": "keyword"
-            },
-            "id_filter": {
-                "type": "integer"
-            },
-            "live_filter": {
-                "type": "boolean"
-            },
-            "owner_id_filter": {
-                "type": "integer"
-            },
             "content_type_id_filter": {
                 "type": "integer"
-            },
-            "path_filter": {
-                "type": "keyword"
             },
             "depth_filter": {
                 "type": "integer"
             },
-            "locked_filter": {
-                "type": "boolean"
-            },
-            "show_in_menus_filter": {
-                "type": "boolean"
-            },
             "first_published_at_filter": {
                 "type": "date"
+            },
+            "id_filter": {
+                "type": "integer"
             },
             "last_published_at_filter": {
                 "type": "date"
@@ -2373,75 +2345,75 @@
             "latest_revision_created_at_filter": {
                 "type": "date"
             },
+            "live_filter": {
+                "type": "boolean"
+            },
             "locale_id_filter": {
                 "type": "integer"
             },
-            "translation_key_filter": {
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
                 "type": "keyword"
             },
-            "_all_text": {
+            "pk": {
+                "store": true,
+                "type": "keyword"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "title": {
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
                 "type": "text"
             },
-            "_all_text_boost_2_0": {
+            "title_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
                 "type": "text"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
             }
         }
     },
     "<class 'working_at_dit.models.GuidanceHome'>": {
         "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            },
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
             },
             "content_type": {
                 "type": "keyword"
             },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title": {
-                "type": "text",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "title_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title_filter": {
-                "type": "keyword"
-            },
-            "id_filter": {
-                "type": "integer"
-            },
-            "live_filter": {
-                "type": "boolean"
-            },
-            "owner_id_filter": {
-                "type": "integer"
-            },
             "content_type_id_filter": {
                 "type": "integer"
-            },
-            "path_filter": {
-                "type": "keyword"
             },
             "depth_filter": {
                 "type": "integer"
             },
-            "locked_filter": {
-                "type": "boolean"
-            },
-            "show_in_menus_filter": {
-                "type": "boolean"
-            },
             "first_published_at_filter": {
                 "type": "date"
+            },
+            "id_filter": {
+                "type": "integer"
             },
             "last_published_at_filter": {
                 "type": "date"
@@ -2449,151 +2421,75 @@
             "latest_revision_created_at_filter": {
                 "type": "date"
             },
+            "live_filter": {
+                "type": "boolean"
+            },
             "locale_id_filter": {
                 "type": "integer"
             },
-            "translation_key_filter": {
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
                 "type": "keyword"
             },
-            "_all_text": {
+            "pk": {
+                "store": true,
+                "type": "keyword"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "title": {
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
                 "type": "text"
             },
-            "_all_text_boost_2_0": {
+            "title_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
                 "type": "text"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
             }
         }
     },
     "<class 'working_at_dit.models.PoliciesAndGuidanceHome'>": {
         "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
-            },
-            "content_type": {
-                "type": "keyword"
-            },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title": {
-                "type": "text",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "title_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title_filter": {
-                "type": "keyword"
-            },
-            "id_filter": {
-                "type": "integer"
-            },
-            "live_filter": {
-                "type": "boolean"
-            },
-            "owner_id_filter": {
-                "type": "integer"
-            },
-            "content_type_id_filter": {
-                "type": "integer"
-            },
-            "path_filter": {
-                "type": "keyword"
-            },
-            "depth_filter": {
-                "type": "integer"
-            },
-            "locked_filter": {
-                "type": "boolean"
-            },
-            "show_in_menus_filter": {
-                "type": "boolean"
-            },
-            "first_published_at_filter": {
-                "type": "date"
-            },
-            "last_published_at_filter": {
-                "type": "date"
-            },
-            "latest_revision_created_at_filter": {
-                "type": "date"
-            },
-            "locale_id_filter": {
-                "type": "integer"
-            },
-            "translation_key_filter": {
-                "type": "keyword"
-            },
             "_all_text": {
                 "type": "text"
             },
             "_all_text_boost_2_0": {
                 "type": "text"
-            }
-        }
-    },
-    "<class 'tools.models.Tool'>": {
-        "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
+            },
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
             },
             "content_type": {
                 "type": "keyword"
             },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title": {
-                "type": "text",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "title_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title_filter": {
-                "type": "keyword"
-            },
-            "id_filter": {
-                "type": "integer"
-            },
-            "live_filter": {
-                "type": "boolean"
-            },
-            "owner_id_filter": {
-                "type": "integer"
-            },
             "content_type_id_filter": {
                 "type": "integer"
-            },
-            "path_filter": {
-                "type": "keyword"
             },
             "depth_filter": {
                 "type": "integer"
             },
-            "locked_filter": {
-                "type": "boolean"
-            },
-            "show_in_menus_filter": {
-                "type": "boolean"
-            },
             "first_published_at_filter": {
                 "type": "date"
+            },
+            "id_filter": {
+                "type": "integer"
             },
             "last_published_at_filter": {
                 "type": "date"
@@ -2601,125 +2497,54 @@
             "latest_revision_created_at_filter": {
                 "type": "date"
             },
+            "live_filter": {
+                "type": "boolean"
+            },
             "locale_id_filter": {
                 "type": "integer"
             },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "pk": {
+                "store": true,
+                "type": "keyword"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "title": {
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "title_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
             "translation_key_filter": {
                 "type": "keyword"
-            },
-            "content_contentpage__search_title_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "content_contentpage__search_title": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "content_contentpage__search_headings_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "content_contentpage__search_headings": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "content_contentpage__search_content_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "content_contentpage__search_content": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "content_contentpage__excerpt_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "content_contentpage__excerpt": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "content_contentpage__is_creatable_filter": {
-                "type": "keyword"
-            },
-            "working_at_dit_pagewithtopics__topic_titles_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "working_at_dit_pagewithtopics__topic_titles": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "tools_tool__search_tool_name_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_10_0"
-                ]
-            },
-            "tools_tool__search_tool_name": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_10_0"
-                ]
-            },
-            "tools_tool__search_tool_name_keyword": {
-                "type": "text",
-                "analyzer": "no_spaces",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_10_0"
-                ]
-            },
-            "tools_tool__search_tool_name_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
+            }
+        }
+    },
+    "<class 'tools.models.Tool'>": {
+        "properties": {
             "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_10_0": {
                 "type": "text"
             },
             "_all_text_boost_1_0": {
@@ -2734,146 +2559,188 @@
             "_all_text_boost_5_0": {
                 "type": "text"
             },
-            "_all_text_boost_10_0": {
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "content_contentpage__excerpt": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__excerpt_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "content_contentpage__search_content": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_content_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_headings": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_headings_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_title": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_title_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "pk": {
+                "store": true,
+                "type": "keyword"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "title": {
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "title_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "tools_tool__search_tool_name": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_10_0"
+                ],
+                "type": "text"
+            },
+            "tools_tool__search_tool_name_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "tools_tool__search_tool_name_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_10_0"
+                ],
+                "type": "text"
+            },
+            "tools_tool__search_tool_name_keyword": {
+                "analyzer": "no_spaces",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_10_0"
+                ],
+                "type": "text"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "working_at_dit_pagewithtopics__topic_titles": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "working_at_dit_pagewithtopics__topic_titles_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
                 "type": "text"
             }
         }
     },
     "<class 'tools.models.ToolsHome'>": {
         "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
-            },
-            "content_type": {
-                "type": "keyword"
-            },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title": {
-                "type": "text",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "title_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title_filter": {
-                "type": "keyword"
-            },
-            "id_filter": {
-                "type": "integer"
-            },
-            "live_filter": {
-                "type": "boolean"
-            },
-            "owner_id_filter": {
-                "type": "integer"
-            },
-            "content_type_id_filter": {
-                "type": "integer"
-            },
-            "path_filter": {
-                "type": "keyword"
-            },
-            "depth_filter": {
-                "type": "integer"
-            },
-            "locked_filter": {
-                "type": "boolean"
-            },
-            "show_in_menus_filter": {
-                "type": "boolean"
-            },
-            "first_published_at_filter": {
-                "type": "date"
-            },
-            "last_published_at_filter": {
-                "type": "date"
-            },
-            "latest_revision_created_at_filter": {
-                "type": "date"
-            },
-            "locale_id_filter": {
-                "type": "integer"
-            },
-            "translation_key_filter": {
-                "type": "keyword"
-            },
-            "tools_toolshome__search_title_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "tools_toolshome__search_title": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "tools_toolshome__search_headings_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "tools_toolshome__search_headings": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "tools_toolshome__search_content_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "tools_toolshome__search_content": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "tools_toolshome__excerpt_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "tools_toolshome__excerpt": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "tools_toolshome__is_creatable_filter": {
-                "type": "keyword"
-            },
             "_all_text": {
                 "type": "text"
             },
@@ -2888,160 +2755,144 @@
             },
             "_all_text_boost_5_0": {
                 "type": "text"
+            },
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "pk": {
+                "store": true,
+                "type": "keyword"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "title": {
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "title_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "tools_toolshome__excerpt": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "tools_toolshome__excerpt_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "tools_toolshome__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "tools_toolshome__search_content": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "tools_toolshome__search_content_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "tools_toolshome__search_headings": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "tools_toolshome__search_headings_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "tools_toolshome__search_title": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "tools_toolshome__search_title_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
             }
         }
     },
     "<class 'about_us.models.AboutUs'>": {
         "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
-            },
-            "content_type": {
-                "type": "keyword"
-            },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title": {
-                "type": "text",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "title_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title_filter": {
-                "type": "keyword"
-            },
-            "id_filter": {
-                "type": "integer"
-            },
-            "live_filter": {
-                "type": "boolean"
-            },
-            "owner_id_filter": {
-                "type": "integer"
-            },
-            "content_type_id_filter": {
-                "type": "integer"
-            },
-            "path_filter": {
-                "type": "keyword"
-            },
-            "depth_filter": {
-                "type": "integer"
-            },
-            "locked_filter": {
-                "type": "boolean"
-            },
-            "show_in_menus_filter": {
-                "type": "boolean"
-            },
-            "first_published_at_filter": {
-                "type": "date"
-            },
-            "last_published_at_filter": {
-                "type": "date"
-            },
-            "latest_revision_created_at_filter": {
-                "type": "date"
-            },
-            "locale_id_filter": {
-                "type": "integer"
-            },
-            "translation_key_filter": {
-                "type": "keyword"
-            },
-            "content_contentpage__search_title_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "content_contentpage__search_title": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "content_contentpage__search_headings_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "content_contentpage__search_headings": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "content_contentpage__search_content_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "content_contentpage__search_content": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "content_contentpage__excerpt_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "content_contentpage__excerpt": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "content_contentpage__is_creatable_filter": {
-                "type": "keyword"
-            },
-            "about_us_aboutus__topic_titles_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "about_us_aboutus__topic_titles": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
             "_all_text": {
                 "type": "text"
             },
@@ -3056,160 +2907,160 @@
             },
             "_all_text_boost_5_0": {
                 "type": "text"
+            },
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "about_us_aboutus__topic_titles": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "about_us_aboutus__topic_titles_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__excerpt": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__excerpt_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "content_contentpage__search_content": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_content_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_headings": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_headings_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_title": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_title_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "pk": {
+                "store": true,
+                "type": "keyword"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "title": {
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "title_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
             }
         }
     },
     "<class 'about_us.models.AboutUsHome'>": {
         "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
-            },
-            "content_type": {
-                "type": "keyword"
-            },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title": {
-                "type": "text",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "title_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title_filter": {
-                "type": "keyword"
-            },
-            "id_filter": {
-                "type": "integer"
-            },
-            "live_filter": {
-                "type": "boolean"
-            },
-            "owner_id_filter": {
-                "type": "integer"
-            },
-            "content_type_id_filter": {
-                "type": "integer"
-            },
-            "path_filter": {
-                "type": "keyword"
-            },
-            "depth_filter": {
-                "type": "integer"
-            },
-            "locked_filter": {
-                "type": "boolean"
-            },
-            "show_in_menus_filter": {
-                "type": "boolean"
-            },
-            "first_published_at_filter": {
-                "type": "date"
-            },
-            "last_published_at_filter": {
-                "type": "date"
-            },
-            "latest_revision_created_at_filter": {
-                "type": "date"
-            },
-            "locale_id_filter": {
-                "type": "integer"
-            },
-            "translation_key_filter": {
-                "type": "keyword"
-            },
-            "content_contentpage__search_title_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "content_contentpage__search_title": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "content_contentpage__search_headings_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "content_contentpage__search_headings": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "content_contentpage__search_content_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "content_contentpage__search_content": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "content_contentpage__excerpt_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "content_contentpage__excerpt": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "content_contentpage__is_creatable_filter": {
-                "type": "keyword"
-            },
-            "about_us_aboutushome__topic_titles_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "about_us_aboutushome__topic_titles": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
             "_all_text": {
                 "type": "text"
             },
@@ -3224,144 +3075,160 @@
             },
             "_all_text_boost_5_0": {
                 "type": "text"
+            },
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "about_us_aboutushome__topic_titles": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "about_us_aboutushome__topic_titles_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__excerpt": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__excerpt_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "content_contentpage__search_content": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_content_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_headings": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_headings_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_title": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_title_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "pk": {
+                "store": true,
+                "type": "keyword"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "title": {
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "title_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
             }
         }
     },
     "<class 'networks.models.NetworksHome'>": {
         "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
-            },
-            "content_type": {
-                "type": "keyword"
-            },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title": {
-                "type": "text",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "title_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title_filter": {
-                "type": "keyword"
-            },
-            "id_filter": {
-                "type": "integer"
-            },
-            "live_filter": {
-                "type": "boolean"
-            },
-            "owner_id_filter": {
-                "type": "integer"
-            },
-            "content_type_id_filter": {
-                "type": "integer"
-            },
-            "path_filter": {
-                "type": "keyword"
-            },
-            "depth_filter": {
-                "type": "integer"
-            },
-            "locked_filter": {
-                "type": "boolean"
-            },
-            "show_in_menus_filter": {
-                "type": "boolean"
-            },
-            "first_published_at_filter": {
-                "type": "date"
-            },
-            "last_published_at_filter": {
-                "type": "date"
-            },
-            "latest_revision_created_at_filter": {
-                "type": "date"
-            },
-            "locale_id_filter": {
-                "type": "integer"
-            },
-            "translation_key_filter": {
-                "type": "keyword"
-            },
-            "networks_networkshome__search_title_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "networks_networkshome__search_title": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "networks_networkshome__search_headings_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "networks_networkshome__search_headings": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "networks_networkshome__search_content_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "networks_networkshome__search_content": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "networks_networkshome__excerpt_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "networks_networkshome__excerpt": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "networks_networkshome__is_creatable_filter": {
-                "type": "keyword"
-            },
             "_all_text": {
                 "type": "text"
             },
@@ -3376,197 +3243,144 @@
             },
             "_all_text_boost_5_0": {
                 "type": "text"
+            },
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "networks_networkshome__excerpt": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "networks_networkshome__excerpt_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "networks_networkshome__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "networks_networkshome__search_content": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "networks_networkshome__search_content_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "networks_networkshome__search_headings": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "networks_networkshome__search_headings_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "networks_networkshome__search_title": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "networks_networkshome__search_title_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "pk": {
+                "store": true,
+                "type": "keyword"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "title": {
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "title_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
             }
         }
     },
     "<class 'networks.models.Network'>": {
         "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
-            },
-            "content_type": {
-                "type": "keyword"
-            },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title": {
-                "type": "text",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "title_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title_filter": {
-                "type": "keyword"
-            },
-            "id_filter": {
-                "type": "integer"
-            },
-            "live_filter": {
-                "type": "boolean"
-            },
-            "owner_id_filter": {
-                "type": "integer"
-            },
-            "content_type_id_filter": {
-                "type": "integer"
-            },
-            "path_filter": {
-                "type": "keyword"
-            },
-            "depth_filter": {
-                "type": "integer"
-            },
-            "locked_filter": {
-                "type": "boolean"
-            },
-            "show_in_menus_filter": {
-                "type": "boolean"
-            },
-            "first_published_at_filter": {
-                "type": "date"
-            },
-            "last_published_at_filter": {
-                "type": "date"
-            },
-            "latest_revision_created_at_filter": {
-                "type": "date"
-            },
-            "locale_id_filter": {
-                "type": "integer"
-            },
-            "translation_key_filter": {
-                "type": "keyword"
-            },
-            "content_contentpage__search_title_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "content_contentpage__search_title": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "content_contentpage__search_headings_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "content_contentpage__search_headings": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "content_contentpage__search_content_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "content_contentpage__search_content": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "content_contentpage__excerpt_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "content_contentpage__excerpt": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "content_contentpage__is_creatable_filter": {
-                "type": "keyword"
-            },
-            "networks_network__topic_titles_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "networks_network__topic_titles": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "networks_network__content_owner": {
-                "type": "nested",
-                "properties": {
-                    "networks_network__first_name_explicit": {
-                        "type": "text",
-                        "analyzer": "simple",
-                        "copy_to": [
-                            "_all_text",
-                            "_all_text_boost_1_0"
-                        ]
-                    },
-                    "networks_network__preferred_first_name_explicit": {
-                        "type": "text",
-                        "analyzer": "simple",
-                        "copy_to": [
-                            "_all_text",
-                            "_all_text_boost_1_0"
-                        ]
-                    },
-                    "networks_network__last_name_explicit": {
-                        "type": "text",
-                        "analyzer": "simple",
-                        "copy_to": [
-                            "_all_text",
-                            "_all_text_boost_1_0"
-                        ]
-                    }
-                }
-            },
-            "networks_network__content_contact_email_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
             "_all_text": {
                 "type": "text"
             },
@@ -3581,144 +3395,197 @@
             },
             "_all_text_boost_5_0": {
                 "type": "text"
+            },
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "content_contentpage__excerpt": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__excerpt_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "content_contentpage__search_content": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_content_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_headings": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_headings_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_title": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "content_contentpage__search_title_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "networks_network__content_contact_email_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "networks_network__content_owner": {
+                "properties": {
+                    "networks_network__first_name_explicit": {
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_0"
+                        ],
+                        "type": "text"
+                    },
+                    "networks_network__last_name_explicit": {
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_0"
+                        ],
+                        "type": "text"
+                    },
+                    "networks_network__preferred_first_name_explicit": {
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_0"
+                        ],
+                        "type": "text"
+                    }
+                },
+                "type": "nested"
+            },
+            "networks_network__topic_titles": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "networks_network__topic_titles_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "pk": {
+                "store": true,
+                "type": "keyword"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "title": {
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "title_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
             }
         }
     },
     "<class 'country_fact_sheet.models.CountryFactSheetHome'>": {
         "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
-            },
-            "content_type": {
-                "type": "keyword"
-            },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title": {
-                "type": "text",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "title_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title_filter": {
-                "type": "keyword"
-            },
-            "id_filter": {
-                "type": "integer"
-            },
-            "live_filter": {
-                "type": "boolean"
-            },
-            "owner_id_filter": {
-                "type": "integer"
-            },
-            "content_type_id_filter": {
-                "type": "integer"
-            },
-            "path_filter": {
-                "type": "keyword"
-            },
-            "depth_filter": {
-                "type": "integer"
-            },
-            "locked_filter": {
-                "type": "boolean"
-            },
-            "show_in_menus_filter": {
-                "type": "boolean"
-            },
-            "first_published_at_filter": {
-                "type": "date"
-            },
-            "last_published_at_filter": {
-                "type": "date"
-            },
-            "latest_revision_created_at_filter": {
-                "type": "date"
-            },
-            "locale_id_filter": {
-                "type": "integer"
-            },
-            "translation_key_filter": {
-                "type": "keyword"
-            },
-            "country_fact_sheet_countryfactsheethome__search_title_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "country_fact_sheet_countryfactsheethome__search_title": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_5_0"
-                ]
-            },
-            "country_fact_sheet_countryfactsheethome__search_headings_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "country_fact_sheet_countryfactsheethome__search_headings": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_3_0"
-                ]
-            },
-            "country_fact_sheet_countryfactsheethome__search_content_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "country_fact_sheet_countryfactsheethome__search_content": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "country_fact_sheet_countryfactsheethome__excerpt_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "country_fact_sheet_countryfactsheethome__excerpt": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "country_fact_sheet_countryfactsheethome__is_creatable_filter": {
-                "type": "keyword"
-            },
             "_all_text": {
                 "type": "text"
             },
@@ -3733,364 +3600,144 @@
             },
             "_all_text_boost_5_0": {
                 "type": "text"
+            },
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "country_fact_sheet_countryfactsheethome__excerpt": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "country_fact_sheet_countryfactsheethome__excerpt_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "country_fact_sheet_countryfactsheethome__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "country_fact_sheet_countryfactsheethome__search_content": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "country_fact_sheet_countryfactsheethome__search_content_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "country_fact_sheet_countryfactsheethome__search_headings": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "country_fact_sheet_countryfactsheethome__search_headings_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ],
+                "type": "text"
+            },
+            "country_fact_sheet_countryfactsheethome__search_title": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "country_fact_sheet_countryfactsheethome__search_title_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ],
+                "type": "text"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "pk": {
+                "store": true,
+                "type": "keyword"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "title": {
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "title_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
             }
         }
     },
     "<class 'peoplefinder.models.Person'>": {
         "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
-            },
-            "content_type": {
-                "type": "keyword"
-            },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "full_name_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_7_0"
-                ]
-            },
-            "full_name": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_7_0"
-                ]
-            },
-            "full_name_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "first_name_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_7_0"
-                ]
-            },
-            "first_name": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_7_0"
-                ]
-            },
-            "first_name_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "preferred_first_name_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_7_0"
-                ]
-            },
-            "preferred_first_name": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_7_0"
-                ]
-            },
-            "preferred_first_name_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "last_name_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_7_0"
-                ]
-            },
-            "last_name": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_7_0"
-                ]
-            },
-            "last_name_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "email": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_4_0"
-                ]
-            },
-            "email_keyword": {
-                "type": "text",
-                "analyzer": "no_spaces",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_4_0"
-                ]
-            },
-            "contact_email": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_4_0"
-                ]
-            },
-            "contact_email_keyword": {
-                "type": "text",
-                "analyzer": "no_spaces",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_4_0"
-                ]
-            },
-            "primary_phone_number": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_4_0"
-                ]
-            },
-            "primary_phone_number_keyword": {
-                "type": "text",
-                "analyzer": "no_spaces",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_4_0"
-                ]
-            },
-            "secondary_phone_number": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_4_0"
-                ]
-            },
-            "secondary_phone_number_keyword": {
-                "type": "text",
-                "analyzer": "no_spaces",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_4_0"
-                ]
-            },
-            "search_grade_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "search_buildings": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "roles": {
-                "type": "nested",
-                "properties": {
-                    "peoplefinder_person__job_title_explicit": {
-                        "type": "text",
-                        "analyzer": "simple",
-                        "copy_to": [
-                            "_all_text",
-                            "_all_text_boost_3_0"
-                        ]
-                    },
-                    "peoplefinder_person__job_title": {
-                        "type": "text",
-                        "analyzer": "snowball",
-                        "copy_to": [
-                            "_all_text",
-                            "_all_text_boost_3_0"
-                        ]
-                    }
-                }
-            },
-            "key_skills": {
-                "type": "nested",
-                "properties": {
-                    "peoplefinder_person__name_explicit": {
-                        "type": "text",
-                        "analyzer": "simple",
-                        "copy_to": [
-                            "_all_text",
-                            "_all_text_boost_0_8"
-                        ]
-                    },
-                    "peoplefinder_person__name": {
-                        "type": "text",
-                        "analyzer": "snowball",
-                        "copy_to": [
-                            "_all_text",
-                            "_all_text_boost_0_8"
-                        ]
-                    }
-                }
-            },
-            "other_key_skills_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_0_8"
-                ]
-            },
-            "other_key_skills": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_0_8"
-                ]
-            },
-            "learning_interests": {
-                "type": "nested",
-                "properties": {
-                    "peoplefinder_person__name": {
-                        "type": "text",
-                        "analyzer": "snowball",
-                        "copy_to": [
-                            "_all_text",
-                            "_all_text_boost_0_8"
-                        ]
-                    }
-                }
-            },
-            "additional_roles": {
-                "type": "nested",
-                "properties": {
-                    "peoplefinder_person__name_explicit": {
-                        "type": "text",
-                        "analyzer": "simple",
-                        "copy_to": [
-                            "_all_text",
-                            "_all_text_boost_0_8"
-                        ]
-                    },
-                    "peoplefinder_person__name": {
-                        "type": "text",
-                        "analyzer": "snowball",
-                        "copy_to": [
-                            "_all_text",
-                            "_all_text_boost_0_8"
-                        ]
-                    }
-                }
-            },
-            "networks": {
-                "type": "nested",
-                "properties": {
-                    "peoplefinder_person__name_explicit": {
-                        "type": "text",
-                        "analyzer": "simple",
-                        "copy_to": [
-                            "_all_text",
-                            "_all_text_boost_1_5"
-                        ]
-                    },
-                    "peoplefinder_person__name": {
-                        "type": "text",
-                        "analyzer": "snowball",
-                        "copy_to": [
-                            "_all_text",
-                            "_all_text_boost_1_5"
-                        ]
-                    },
-                    "peoplefinder_person__name_filter": {
-                        "type": "keyword"
-                    }
-                }
-            },
-            "networks_filter": {
-                "type": "integer"
-            },
-            "international_building": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "search_location": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "fluent_languages": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "search_teams_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "search_teams": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "profile_completion_scorefunction_filter": {
-                "type": "integer"
-            },
-            "is_active_filter": {
-                "type": "boolean"
-            },
-            "became_inactive_filter": {
-                "type": "date"
-            },
-            "professions_filter": {
-                "type": "integer"
-            },
-            "grade_id_filter": {
-                "type": "integer"
-            },
-            "do_not_work_for_dit_filter": {
-                "type": "boolean"
-            },
             "_all_text": {
                 "type": "text"
             },
@@ -4103,111 +3750,375 @@
             "_all_text_boost_1_5": {
                 "type": "text"
             },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            },
             "_all_text_boost_3_0": {
                 "type": "text"
             },
             "_all_text_boost_4_0": {
                 "type": "text"
             },
-            "_all_text_boost_2_0": {
+            "_all_text_boost_7_0": {
                 "type": "text"
             },
-            "_all_text_boost_7_0": {
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "additional_roles": {
+                "properties": {
+                    "peoplefinder_person__name": {
+                        "analyzer": "snowball",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_0_8"
+                        ],
+                        "type": "text"
+                    },
+                    "peoplefinder_person__name_explicit": {
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_0_8"
+                        ],
+                        "type": "text"
+                    }
+                },
+                "type": "nested"
+            },
+            "became_inactive_filter": {
+                "type": "date"
+            },
+            "contact_email": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_4_0"
+                ],
+                "type": "text"
+            },
+            "contact_email_keyword": {
+                "analyzer": "no_spaces",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_4_0"
+                ],
+                "type": "text"
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "do_not_work_for_dit_filter": {
+                "type": "boolean"
+            },
+            "email": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_4_0"
+                ],
+                "type": "text"
+            },
+            "email_keyword": {
+                "analyzer": "no_spaces",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_4_0"
+                ],
+                "type": "text"
+            },
+            "first_name": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_7_0"
+                ],
+                "type": "text"
+            },
+            "first_name_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "first_name_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_7_0"
+                ],
+                "type": "text"
+            },
+            "fluent_languages": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "full_name": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_7_0"
+                ],
+                "type": "text"
+            },
+            "full_name_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "full_name_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_7_0"
+                ],
+                "type": "text"
+            },
+            "grade_id_filter": {
+                "type": "integer"
+            },
+            "international_building": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "is_active_filter": {
+                "type": "boolean"
+            },
+            "key_skills": {
+                "properties": {
+                    "peoplefinder_person__name": {
+                        "analyzer": "snowball",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_0_8"
+                        ],
+                        "type": "text"
+                    },
+                    "peoplefinder_person__name_explicit": {
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_0_8"
+                        ],
+                        "type": "text"
+                    }
+                },
+                "type": "nested"
+            },
+            "last_name": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_7_0"
+                ],
+                "type": "text"
+            },
+            "last_name_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "last_name_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_7_0"
+                ],
+                "type": "text"
+            },
+            "learning_interests": {
+                "properties": {
+                    "peoplefinder_person__name": {
+                        "analyzer": "snowball",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_0_8"
+                        ],
+                        "type": "text"
+                    }
+                },
+                "type": "nested"
+            },
+            "networks": {
+                "properties": {
+                    "peoplefinder_person__name": {
+                        "analyzer": "snowball",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_5"
+                        ],
+                        "type": "text"
+                    },
+                    "peoplefinder_person__name_explicit": {
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_5"
+                        ],
+                        "type": "text"
+                    },
+                    "peoplefinder_person__name_filter": {
+                        "type": "keyword"
+                    }
+                },
+                "type": "nested"
+            },
+            "networks_filter": {
+                "type": "integer"
+            },
+            "other_key_skills": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_0_8"
+                ],
+                "type": "text"
+            },
+            "other_key_skills_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_0_8"
+                ],
+                "type": "text"
+            },
+            "pk": {
+                "store": true,
+                "type": "keyword"
+            },
+            "preferred_first_name": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_7_0"
+                ],
+                "type": "text"
+            },
+            "preferred_first_name_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "preferred_first_name_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_7_0"
+                ],
+                "type": "text"
+            },
+            "primary_phone_number": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_4_0"
+                ],
+                "type": "text"
+            },
+            "primary_phone_number_keyword": {
+                "analyzer": "no_spaces",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_4_0"
+                ],
+                "type": "text"
+            },
+            "professions_filter": {
+                "type": "integer"
+            },
+            "profile_completion_scorefunction_filter": {
+                "type": "integer"
+            },
+            "roles": {
+                "properties": {
+                    "peoplefinder_person__job_title": {
+                        "analyzer": "snowball",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_3_0"
+                        ],
+                        "type": "text"
+                    },
+                    "peoplefinder_person__job_title_explicit": {
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_3_0"
+                        ],
+                        "type": "text"
+                    }
+                },
+                "type": "nested"
+            },
+            "search_buildings": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "search_grade_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "search_location": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "search_teams": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "search_teams_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "secondary_phone_number": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_4_0"
+                ],
+                "type": "text"
+            },
+            "secondary_phone_number_keyword": {
+                "analyzer": "no_spaces",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_4_0"
+                ],
                 "type": "text"
             }
         }
     },
     "<class 'peoplefinder.models.Team'>": {
         "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
-            },
-            "content_type": {
-                "type": "keyword"
-            },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "name_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_4_0"
-                ]
-            },
-            "name": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_4_0"
-                ]
-            },
-            "name_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "abbreviation_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_4_0"
-                ]
-            },
-            "abbreviation": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_4_0"
-                ]
-            },
-            "abbreviation_keyword": {
-                "type": "text",
-                "analyzer": "no_spaces",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_4_0"
-                ]
-            },
-            "description_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "description": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_1_0"
-                ]
-            },
-            "roles_in_team_explicit": {
-                "type": "text",
-                "analyzer": "simple",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "roles_in_team": {
-                "type": "text",
-                "analyzer": "snowball",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
             "_all_text": {
                 "type": "text"
             },
@@ -4219,184 +4130,245 @@
             },
             "_all_text_boost_4_0": {
                 "type": "text"
+            },
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "abbreviation": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_4_0"
+                ],
+                "type": "text"
+            },
+            "abbreviation_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_4_0"
+                ],
+                "type": "text"
+            },
+            "abbreviation_keyword": {
+                "analyzer": "no_spaces",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_4_0"
+                ],
+                "type": "text"
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "description": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "description_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ],
+                "type": "text"
+            },
+            "name": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_4_0"
+                ],
+                "type": "text"
+            },
+            "name_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "name_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_4_0"
+                ],
+                "type": "text"
+            },
+            "pk": {
+                "store": true,
+                "type": "keyword"
+            },
+            "roles_in_team": {
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
+            },
+            "roles_in_team_explicit": {
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
+                "type": "text"
             }
         }
     },
     "<class 'wagtail.documents.models.Document'>": {
         "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
-            },
-            "content_type": {
-                "type": "keyword"
-            },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "collection_id_filter": {
-                "type": "integer"
-            },
-            "title": {
-                "type": "text",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_10_0"
-                ]
-            },
-            "title_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title_filter": {
-                "type": "keyword"
-            },
-            "tags": {
-                "type": "nested",
-                "properties": {
-                    "name": {
-                        "type": "text",
-                        "copy_to": [
-                            "_all_text",
-                            "_all_text_boost_10_0"
-                        ]
-                    },
-                    "name_edgengrams": {
-                        "type": "text",
-                        "analyzer": "edgengram_analyzer",
-                        "search_analyzer": "standard"
-                    }
-                }
-            },
-            "uploaded_by_user_id_filter": {
-                "type": "integer"
-            },
             "_all_text": {
                 "type": "text"
             },
             "_all_text_boost_10_0": {
                 "type": "text"
+            },
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "collection_id_filter": {
+                "type": "integer"
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "pk": {
+                "store": true,
+                "type": "keyword"
+            },
+            "tags": {
+                "properties": {
+                    "name": {
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_10_0"
+                        ],
+                        "type": "text"
+                    },
+                    "name_edgengrams": {
+                        "analyzer": "edgengram_analyzer",
+                        "search_analyzer": "standard",
+                        "type": "text"
+                    }
+                },
+                "type": "nested"
+            },
+            "title": {
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_10_0"
+                ],
+                "type": "text"
+            },
+            "title_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "uploaded_by_user_id_filter": {
+                "type": "integer"
             }
         }
     },
     "<class 'wagtail.images.models.Image'>": {
         "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
-            },
-            "content_type": {
-                "type": "keyword"
-            },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "collection_id_filter": {
-                "type": "integer"
-            },
-            "title": {
-                "type": "text",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_10_0"
-                ]
-            },
-            "title_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title_filter": {
-                "type": "keyword"
-            },
-            "tags": {
-                "type": "nested",
-                "properties": {
-                    "name": {
-                        "type": "text",
-                        "copy_to": [
-                            "_all_text",
-                            "_all_text_boost_10_0"
-                        ]
-                    },
-                    "name_edgengrams": {
-                        "type": "text",
-                        "analyzer": "edgengram_analyzer",
-                        "search_analyzer": "standard"
-                    }
-                }
-            },
-            "uploaded_by_user_id_filter": {
-                "type": "integer"
-            },
             "_all_text": {
                 "type": "text"
             },
             "_all_text_boost_10_0": {
                 "type": "text"
+            },
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "collection_id_filter": {
+                "type": "integer"
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "pk": {
+                "store": true,
+                "type": "keyword"
+            },
+            "tags": {
+                "properties": {
+                    "name": {
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_10_0"
+                        ],
+                        "type": "text"
+                    },
+                    "name_edgengrams": {
+                        "analyzer": "edgengram_analyzer",
+                        "search_analyzer": "standard",
+                        "type": "text"
+                    }
+                },
+                "type": "nested"
+            },
+            "title": {
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_10_0"
+                ],
+                "type": "text"
+            },
+            "title_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "uploaded_by_user_id_filter": {
+                "type": "integer"
             }
         }
     },
     "<class 'wagtail.models.Page'>": {
         "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            },
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
             },
             "content_type": {
                 "type": "keyword"
             },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title": {
-                "type": "text",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_2_0"
-                ]
-            },
-            "title_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title_filter": {
-                "type": "keyword"
-            },
-            "id_filter": {
-                "type": "integer"
-            },
-            "live_filter": {
-                "type": "boolean"
-            },
-            "owner_id_filter": {
-                "type": "integer"
-            },
             "content_type_id_filter": {
                 "type": "integer"
-            },
-            "path_filter": {
-                "type": "keyword"
             },
             "depth_filter": {
                 "type": "integer"
             },
-            "locked_filter": {
-                "type": "boolean"
-            },
-            "show_in_menus_filter": {
-                "type": "boolean"
-            },
             "first_published_at_filter": {
                 "type": "date"
+            },
+            "id_filter": {
+                "type": "integer"
             },
             "last_published_at_filter": {
                 "type": "date"
@@ -4404,77 +4376,105 @@
             "latest_revision_created_at_filter": {
                 "type": "date"
             },
+            "live_filter": {
+                "type": "boolean"
+            },
             "locale_id_filter": {
                 "type": "integer"
             },
-            "translation_key_filter": {
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
                 "type": "keyword"
             },
-            "_all_text": {
+            "pk": {
+                "store": true,
+                "type": "keyword"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "title": {
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ],
                 "type": "text"
             },
-            "_all_text_boost_2_0": {
+            "title_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
                 "type": "text"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
             }
         }
     },
     "<class 'wagtailmedia.models.Media'>": {
         "properties": {
-            "pk": {
-                "type": "keyword",
-                "store": true
-            },
-            "content_type": {
-                "type": "keyword"
-            },
-            "_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "collection_id_filter": {
-                "type": "integer"
-            },
-            "title": {
-                "type": "text",
-                "copy_to": [
-                    "_all_text",
-                    "_all_text_boost_10_0"
-                ]
-            },
-            "title_edgengrams": {
-                "type": "text",
-                "analyzer": "edgengram_analyzer",
-                "search_analyzer": "standard"
-            },
-            "title_filter": {
-                "type": "keyword"
-            },
-            "tags": {
-                "type": "nested",
-                "properties": {
-                    "name": {
-                        "type": "text",
-                        "copy_to": [
-                            "_all_text",
-                            "_all_text_boost_10_0"
-                        ]
-                    },
-                    "name_edgengrams": {
-                        "type": "text",
-                        "analyzer": "edgengram_analyzer",
-                        "search_analyzer": "standard"
-                    }
-                }
-            },
-            "uploaded_by_user_id_filter": {
-                "type": "integer"
-            },
             "_all_text": {
                 "type": "text"
             },
             "_all_text_boost_10_0": {
                 "type": "text"
+            },
+            "_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "collection_id_filter": {
+                "type": "integer"
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "pk": {
+                "store": true,
+                "type": "keyword"
+            },
+            "tags": {
+                "properties": {
+                    "name": {
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_10_0"
+                        ],
+                        "type": "text"
+                    },
+                    "name_edgengrams": {
+                        "analyzer": "edgengram_analyzer",
+                        "search_analyzer": "standard",
+                        "type": "text"
+                    }
+                },
+                "type": "nested"
+            },
+            "title": {
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_10_0"
+                ],
+                "type": "text"
+            },
+            "title_edgengrams": {
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard",
+                "type": "text"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "uploaded_by_user_id_filter": {
+                "type": "integer"
             }
         }
     }

--- a/src/extended_search/management/commands/indexed_mapping.json
+++ b/src/extended_search/management/commands/indexed_mapping.json
@@ -1,0 +1,4481 @@
+{
+    "<class 'core.models.tags.Tag'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "name": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "name_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_1_0": {
+                "type": "text"
+            }
+        }
+    },
+    "<class 'home.models.HomePage'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title": {
+                "type": "text",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "title_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            }
+        }
+    },
+    "<class 'content.models.BasePage'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title": {
+                "type": "text",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "title_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            }
+        }
+    },
+    "<class 'content.models.ContentPage'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title": {
+                "type": "text",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "title_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "content_contentpage__search_title_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "content_contentpage__search_title": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "content_contentpage__search_headings_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "content_contentpage__search_headings": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "content_contentpage__search_content_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "content_contentpage__search_content": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "content_contentpage__excerpt_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "content_contentpage__excerpt": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "content_contentpage__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_1_0": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            },
+            "_all_text_boost_3_0": {
+                "type": "text"
+            },
+            "_all_text_boost_5_0": {
+                "type": "text"
+            }
+        }
+    },
+    "<class 'content.models.NavigationPage'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title": {
+                "type": "text",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "title_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "content_navigationpage__search_title_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "content_navigationpage__search_title": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "content_navigationpage__search_headings_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "content_navigationpage__search_headings": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "content_navigationpage__search_content_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "content_navigationpage__search_content": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_1_0": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            },
+            "_all_text_boost_3_0": {
+                "type": "text"
+            },
+            "_all_text_boost_5_0": {
+                "type": "text"
+            }
+        }
+    },
+    "<class 'content.models.BlogIndex'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title": {
+                "type": "text",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "title_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            }
+        }
+    },
+    "<class 'content.models.BlogPost'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title": {
+                "type": "text",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "title_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "content_blogpost__search_title_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "content_blogpost__search_title": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "content_blogpost__search_headings_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "content_blogpost__search_headings": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "content_blogpost__search_content_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "content_blogpost__search_content": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "content_blogpost__excerpt_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "content_blogpost__excerpt": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "content_blogpost__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_1_0": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            },
+            "_all_text_boost_3_0": {
+                "type": "text"
+            },
+            "_all_text_boost_5_0": {
+                "type": "text"
+            }
+        }
+    },
+    "<class 'news.models.NewsPage'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title": {
+                "type": "text",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "title_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "news_newspage__last_published_at_scorefunction_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "content_contentpage__search_title_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "content_contentpage__search_title": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "content_contentpage__search_headings_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "content_contentpage__search_headings": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "content_contentpage__search_content_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "content_contentpage__search_content": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "content_contentpage__excerpt_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "content_contentpage__excerpt": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "content_contentpage__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "working_at_dit_pagewithtopics__topic_titles_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "working_at_dit_pagewithtopics__topic_titles": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "news_newspage__search_categories": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "news_newspage__search_categories_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "news_newspage__pinned_on_home_filter": {
+                "type": "boolean"
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_1_0": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            },
+            "_all_text_boost_3_0": {
+                "type": "text"
+            },
+            "_all_text_boost_5_0": {
+                "type": "text"
+            }
+        }
+    },
+    "<class 'news.models.NewsHome'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title": {
+                "type": "text",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "title_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            }
+        }
+    },
+    "<class 'working_at_dit.models.WorkingAtDITHome'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title": {
+                "type": "text",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "title_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "working_at_dit_workingatdithome__search_title_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "working_at_dit_workingatdithome__search_title": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "working_at_dit_workingatdithome__search_headings_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "working_at_dit_workingatdithome__search_headings": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "working_at_dit_workingatdithome__search_content_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "working_at_dit_workingatdithome__search_content": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "working_at_dit_workingatdithome__excerpt_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "working_at_dit_workingatdithome__excerpt": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "working_at_dit_workingatdithome__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_1_0": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            },
+            "_all_text_boost_3_0": {
+                "type": "text"
+            },
+            "_all_text_boost_5_0": {
+                "type": "text"
+            }
+        }
+    },
+    "<class 'working_at_dit.models.Topic'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title": {
+                "type": "text",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "title_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "content_contentpage__search_title_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "content_contentpage__search_title": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "content_contentpage__search_headings_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "content_contentpage__search_headings": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "content_contentpage__search_content_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "content_contentpage__search_content": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "content_contentpage__excerpt_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "content_contentpage__excerpt": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "content_contentpage__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "working_at_dit_topic__content_owner": {
+                "type": "nested",
+                "properties": {
+                    "working_at_dit_topic__first_name_explicit": {
+                        "type": "text",
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_0"
+                        ]
+                    },
+                    "working_at_dit_topic__preferred_first_name_explicit": {
+                        "type": "text",
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_0"
+                        ]
+                    },
+                    "working_at_dit_topic__last_name_explicit": {
+                        "type": "text",
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_0"
+                        ]
+                    }
+                }
+            },
+            "working_at_dit_topic__content_contact_email_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_1_0": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            },
+            "_all_text_boost_3_0": {
+                "type": "text"
+            },
+            "_all_text_boost_5_0": {
+                "type": "text"
+            }
+        }
+    },
+    "<class 'working_at_dit.models.TopicHome'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title": {
+                "type": "text",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "title_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            }
+        }
+    },
+    "<class 'working_at_dit.models.PageWithTopics'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title": {
+                "type": "text",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "title_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "content_contentpage__search_title_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "content_contentpage__search_title": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "content_contentpage__search_headings_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "content_contentpage__search_headings": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "content_contentpage__search_content_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "content_contentpage__search_content": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "content_contentpage__excerpt_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "content_contentpage__excerpt": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "content_contentpage__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "working_at_dit_pagewithtopics__topic_titles_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "working_at_dit_pagewithtopics__topic_titles": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_1_0": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            },
+            "_all_text_boost_3_0": {
+                "type": "text"
+            },
+            "_all_text_boost_5_0": {
+                "type": "text"
+            }
+        }
+    },
+    "<class 'working_at_dit.models.HowDoI'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title": {
+                "type": "text",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "title_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "content_contentpage__search_title_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "content_contentpage__search_title": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "content_contentpage__search_headings_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "content_contentpage__search_headings": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "content_contentpage__search_content_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "content_contentpage__search_content": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "content_contentpage__excerpt_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "content_contentpage__excerpt": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "content_contentpage__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "working_at_dit_pagewithtopics__topic_titles_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "working_at_dit_pagewithtopics__topic_titles": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "working_at_dit_howdoi__content_owner": {
+                "type": "nested",
+                "properties": {
+                    "working_at_dit_howdoi__first_name_explicit": {
+                        "type": "text",
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_0"
+                        ]
+                    },
+                    "working_at_dit_howdoi__preferred_first_name_explicit": {
+                        "type": "text",
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_0"
+                        ]
+                    },
+                    "working_at_dit_howdoi__last_name_explicit": {
+                        "type": "text",
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_0"
+                        ]
+                    }
+                }
+            },
+            "working_at_dit_howdoi__content_contact_email_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_1_0": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            },
+            "_all_text_boost_3_0": {
+                "type": "text"
+            },
+            "_all_text_boost_5_0": {
+                "type": "text"
+            }
+        }
+    },
+    "<class 'working_at_dit.models.HowDoIHome'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title": {
+                "type": "text",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "title_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "working_at_dit_howdoihome__search_title_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "working_at_dit_howdoihome__search_title": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "working_at_dit_howdoihome__search_headings_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "working_at_dit_howdoihome__search_headings": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "working_at_dit_howdoihome__search_content_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "working_at_dit_howdoihome__search_content": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "working_at_dit_howdoihome__excerpt_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "working_at_dit_howdoihome__excerpt": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "working_at_dit_howdoihome__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_1_0": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            },
+            "_all_text_boost_3_0": {
+                "type": "text"
+            },
+            "_all_text_boost_5_0": {
+                "type": "text"
+            }
+        }
+    },
+    "<class 'working_at_dit.models.Guidance'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title": {
+                "type": "text",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "title_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "content_contentpage__search_title_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "content_contentpage__search_title": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "content_contentpage__search_headings_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "content_contentpage__search_headings": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "content_contentpage__search_content_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "content_contentpage__search_content": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "content_contentpage__excerpt_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "content_contentpage__excerpt": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "content_contentpage__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "working_at_dit_pagewithtopics__topic_titles_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "working_at_dit_pagewithtopics__topic_titles": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "working_at_dit_guidance__content_owner": {
+                "type": "nested",
+                "properties": {
+                    "working_at_dit_guidance__first_name_explicit": {
+                        "type": "text",
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_0"
+                        ]
+                    },
+                    "working_at_dit_guidance__preferred_first_name_explicit": {
+                        "type": "text",
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_0"
+                        ]
+                    },
+                    "working_at_dit_guidance__last_name_explicit": {
+                        "type": "text",
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_0"
+                        ]
+                    }
+                }
+            },
+            "working_at_dit_guidance__content_contact_email_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_1_0": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            },
+            "_all_text_boost_3_0": {
+                "type": "text"
+            },
+            "_all_text_boost_5_0": {
+                "type": "text"
+            }
+        }
+    },
+    "<class 'working_at_dit.models.Policy'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title": {
+                "type": "text",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "title_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "content_contentpage__search_title_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "content_contentpage__search_title": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "content_contentpage__search_headings_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "content_contentpage__search_headings": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "content_contentpage__search_content_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "content_contentpage__search_content": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "content_contentpage__excerpt_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "content_contentpage__excerpt": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "content_contentpage__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "working_at_dit_pagewithtopics__topic_titles_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "working_at_dit_pagewithtopics__topic_titles": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "working_at_dit_policy__content_owner": {
+                "type": "nested",
+                "properties": {
+                    "working_at_dit_policy__first_name_explicit": {
+                        "type": "text",
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_0"
+                        ]
+                    },
+                    "working_at_dit_policy__preferred_first_name_explicit": {
+                        "type": "text",
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_0"
+                        ]
+                    },
+                    "working_at_dit_policy__last_name_explicit": {
+                        "type": "text",
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_0"
+                        ]
+                    }
+                }
+            },
+            "working_at_dit_policy__content_contact_email_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_1_0": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            },
+            "_all_text_boost_3_0": {
+                "type": "text"
+            },
+            "_all_text_boost_5_0": {
+                "type": "text"
+            }
+        }
+    },
+    "<class 'working_at_dit.models.PoliciesHome'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title": {
+                "type": "text",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "title_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            }
+        }
+    },
+    "<class 'working_at_dit.models.GuidanceHome'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title": {
+                "type": "text",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "title_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            }
+        }
+    },
+    "<class 'working_at_dit.models.PoliciesAndGuidanceHome'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title": {
+                "type": "text",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "title_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            }
+        }
+    },
+    "<class 'tools.models.Tool'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title": {
+                "type": "text",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "title_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "content_contentpage__search_title_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "content_contentpage__search_title": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "content_contentpage__search_headings_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "content_contentpage__search_headings": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "content_contentpage__search_content_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "content_contentpage__search_content": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "content_contentpage__excerpt_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "content_contentpage__excerpt": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "content_contentpage__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "working_at_dit_pagewithtopics__topic_titles_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "working_at_dit_pagewithtopics__topic_titles": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "tools_tool__search_tool_name_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_10_0"
+                ]
+            },
+            "tools_tool__search_tool_name": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_10_0"
+                ]
+            },
+            "tools_tool__search_tool_name_keyword": {
+                "type": "text",
+                "analyzer": "no_spaces",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_10_0"
+                ]
+            },
+            "tools_tool__search_tool_name_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_1_0": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            },
+            "_all_text_boost_3_0": {
+                "type": "text"
+            },
+            "_all_text_boost_5_0": {
+                "type": "text"
+            },
+            "_all_text_boost_10_0": {
+                "type": "text"
+            }
+        }
+    },
+    "<class 'tools.models.ToolsHome'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title": {
+                "type": "text",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "title_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "tools_toolshome__search_title_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "tools_toolshome__search_title": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "tools_toolshome__search_headings_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "tools_toolshome__search_headings": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "tools_toolshome__search_content_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "tools_toolshome__search_content": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "tools_toolshome__excerpt_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "tools_toolshome__excerpt": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "tools_toolshome__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_1_0": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            },
+            "_all_text_boost_3_0": {
+                "type": "text"
+            },
+            "_all_text_boost_5_0": {
+                "type": "text"
+            }
+        }
+    },
+    "<class 'about_us.models.AboutUs'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title": {
+                "type": "text",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "title_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "content_contentpage__search_title_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "content_contentpage__search_title": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "content_contentpage__search_headings_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "content_contentpage__search_headings": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "content_contentpage__search_content_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "content_contentpage__search_content": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "content_contentpage__excerpt_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "content_contentpage__excerpt": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "content_contentpage__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "about_us_aboutus__topic_titles_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "about_us_aboutus__topic_titles": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_1_0": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            },
+            "_all_text_boost_3_0": {
+                "type": "text"
+            },
+            "_all_text_boost_5_0": {
+                "type": "text"
+            }
+        }
+    },
+    "<class 'about_us.models.AboutUsHome'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title": {
+                "type": "text",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "title_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "content_contentpage__search_title_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "content_contentpage__search_title": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "content_contentpage__search_headings_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "content_contentpage__search_headings": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "content_contentpage__search_content_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "content_contentpage__search_content": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "content_contentpage__excerpt_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "content_contentpage__excerpt": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "content_contentpage__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "about_us_aboutushome__topic_titles_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "about_us_aboutushome__topic_titles": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_1_0": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            },
+            "_all_text_boost_3_0": {
+                "type": "text"
+            },
+            "_all_text_boost_5_0": {
+                "type": "text"
+            }
+        }
+    },
+    "<class 'networks.models.NetworksHome'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title": {
+                "type": "text",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "title_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "networks_networkshome__search_title_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "networks_networkshome__search_title": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "networks_networkshome__search_headings_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "networks_networkshome__search_headings": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "networks_networkshome__search_content_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "networks_networkshome__search_content": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "networks_networkshome__excerpt_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "networks_networkshome__excerpt": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "networks_networkshome__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_1_0": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            },
+            "_all_text_boost_3_0": {
+                "type": "text"
+            },
+            "_all_text_boost_5_0": {
+                "type": "text"
+            }
+        }
+    },
+    "<class 'networks.models.Network'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title": {
+                "type": "text",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "title_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "content_contentpage__search_title_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "content_contentpage__search_title": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "content_contentpage__search_headings_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "content_contentpage__search_headings": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "content_contentpage__search_content_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "content_contentpage__search_content": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "content_contentpage__excerpt_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "content_contentpage__excerpt": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "content_contentpage__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "networks_network__topic_titles_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "networks_network__topic_titles": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "networks_network__content_owner": {
+                "type": "nested",
+                "properties": {
+                    "networks_network__first_name_explicit": {
+                        "type": "text",
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_0"
+                        ]
+                    },
+                    "networks_network__preferred_first_name_explicit": {
+                        "type": "text",
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_0"
+                        ]
+                    },
+                    "networks_network__last_name_explicit": {
+                        "type": "text",
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_0"
+                        ]
+                    }
+                }
+            },
+            "networks_network__content_contact_email_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_1_0": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            },
+            "_all_text_boost_3_0": {
+                "type": "text"
+            },
+            "_all_text_boost_5_0": {
+                "type": "text"
+            }
+        }
+    },
+    "<class 'country_fact_sheet.models.CountryFactSheetHome'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title": {
+                "type": "text",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "title_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "country_fact_sheet_countryfactsheethome__search_title_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "country_fact_sheet_countryfactsheethome__search_title": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_5_0"
+                ]
+            },
+            "country_fact_sheet_countryfactsheethome__search_headings_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "country_fact_sheet_countryfactsheethome__search_headings": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_3_0"
+                ]
+            },
+            "country_fact_sheet_countryfactsheethome__search_content_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "country_fact_sheet_countryfactsheethome__search_content": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "country_fact_sheet_countryfactsheethome__excerpt_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "country_fact_sheet_countryfactsheethome__excerpt": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "country_fact_sheet_countryfactsheethome__is_creatable_filter": {
+                "type": "keyword"
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_1_0": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            },
+            "_all_text_boost_3_0": {
+                "type": "text"
+            },
+            "_all_text_boost_5_0": {
+                "type": "text"
+            }
+        }
+    },
+    "<class 'peoplefinder.models.Person'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "full_name_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_7_0"
+                ]
+            },
+            "full_name": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_7_0"
+                ]
+            },
+            "full_name_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "first_name_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_7_0"
+                ]
+            },
+            "first_name": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_7_0"
+                ]
+            },
+            "first_name_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "preferred_first_name_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_7_0"
+                ]
+            },
+            "preferred_first_name": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_7_0"
+                ]
+            },
+            "preferred_first_name_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "last_name_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_7_0"
+                ]
+            },
+            "last_name": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_7_0"
+                ]
+            },
+            "last_name_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "email": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_4_0"
+                ]
+            },
+            "email_keyword": {
+                "type": "text",
+                "analyzer": "no_spaces",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_4_0"
+                ]
+            },
+            "contact_email": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_4_0"
+                ]
+            },
+            "contact_email_keyword": {
+                "type": "text",
+                "analyzer": "no_spaces",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_4_0"
+                ]
+            },
+            "primary_phone_number": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_4_0"
+                ]
+            },
+            "primary_phone_number_keyword": {
+                "type": "text",
+                "analyzer": "no_spaces",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_4_0"
+                ]
+            },
+            "secondary_phone_number": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_4_0"
+                ]
+            },
+            "secondary_phone_number_keyword": {
+                "type": "text",
+                "analyzer": "no_spaces",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_4_0"
+                ]
+            },
+            "search_grade_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "search_buildings": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "roles": {
+                "type": "nested",
+                "properties": {
+                    "peoplefinder_person__job_title_explicit": {
+                        "type": "text",
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_3_0"
+                        ]
+                    },
+                    "peoplefinder_person__job_title": {
+                        "type": "text",
+                        "analyzer": "snowball",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_3_0"
+                        ]
+                    }
+                }
+            },
+            "key_skills": {
+                "type": "nested",
+                "properties": {
+                    "peoplefinder_person__name_explicit": {
+                        "type": "text",
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_0_8"
+                        ]
+                    },
+                    "peoplefinder_person__name": {
+                        "type": "text",
+                        "analyzer": "snowball",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_0_8"
+                        ]
+                    }
+                }
+            },
+            "other_key_skills_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_0_8"
+                ]
+            },
+            "other_key_skills": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_0_8"
+                ]
+            },
+            "learning_interests": {
+                "type": "nested",
+                "properties": {
+                    "peoplefinder_person__name": {
+                        "type": "text",
+                        "analyzer": "snowball",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_0_8"
+                        ]
+                    }
+                }
+            },
+            "additional_roles": {
+                "type": "nested",
+                "properties": {
+                    "peoplefinder_person__name_explicit": {
+                        "type": "text",
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_0_8"
+                        ]
+                    },
+                    "peoplefinder_person__name": {
+                        "type": "text",
+                        "analyzer": "snowball",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_0_8"
+                        ]
+                    }
+                }
+            },
+            "networks": {
+                "type": "nested",
+                "properties": {
+                    "peoplefinder_person__name_explicit": {
+                        "type": "text",
+                        "analyzer": "simple",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_5"
+                        ]
+                    },
+                    "peoplefinder_person__name": {
+                        "type": "text",
+                        "analyzer": "snowball",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_1_5"
+                        ]
+                    },
+                    "peoplefinder_person__name_filter": {
+                        "type": "keyword"
+                    }
+                }
+            },
+            "networks_filter": {
+                "type": "integer"
+            },
+            "international_building": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "search_location": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "fluent_languages": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "search_teams_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "search_teams": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "profile_completion_scorefunction_filter": {
+                "type": "integer"
+            },
+            "is_active_filter": {
+                "type": "boolean"
+            },
+            "became_inactive_filter": {
+                "type": "date"
+            },
+            "professions_filter": {
+                "type": "integer"
+            },
+            "grade_id_filter": {
+                "type": "integer"
+            },
+            "do_not_work_for_dit_filter": {
+                "type": "boolean"
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_0_8": {
+                "type": "text"
+            },
+            "_all_text_boost_1_0": {
+                "type": "text"
+            },
+            "_all_text_boost_1_5": {
+                "type": "text"
+            },
+            "_all_text_boost_3_0": {
+                "type": "text"
+            },
+            "_all_text_boost_4_0": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            },
+            "_all_text_boost_7_0": {
+                "type": "text"
+            }
+        }
+    },
+    "<class 'peoplefinder.models.Team'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "name_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_4_0"
+                ]
+            },
+            "name": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_4_0"
+                ]
+            },
+            "name_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "abbreviation_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_4_0"
+                ]
+            },
+            "abbreviation": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_4_0"
+                ]
+            },
+            "abbreviation_keyword": {
+                "type": "text",
+                "analyzer": "no_spaces",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_4_0"
+                ]
+            },
+            "description_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "description": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_1_0"
+                ]
+            },
+            "roles_in_team_explicit": {
+                "type": "text",
+                "analyzer": "simple",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "roles_in_team": {
+                "type": "text",
+                "analyzer": "snowball",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_1_0": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            },
+            "_all_text_boost_4_0": {
+                "type": "text"
+            }
+        }
+    },
+    "<class 'wagtail.documents.models.Document'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "collection_id_filter": {
+                "type": "integer"
+            },
+            "title": {
+                "type": "text",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_10_0"
+                ]
+            },
+            "title_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "tags": {
+                "type": "nested",
+                "properties": {
+                    "name": {
+                        "type": "text",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_10_0"
+                        ]
+                    },
+                    "name_edgengrams": {
+                        "type": "text",
+                        "analyzer": "edgengram_analyzer",
+                        "search_analyzer": "standard"
+                    }
+                }
+            },
+            "uploaded_by_user_id_filter": {
+                "type": "integer"
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_10_0": {
+                "type": "text"
+            }
+        }
+    },
+    "<class 'wagtail.images.models.Image'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "collection_id_filter": {
+                "type": "integer"
+            },
+            "title": {
+                "type": "text",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_10_0"
+                ]
+            },
+            "title_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "tags": {
+                "type": "nested",
+                "properties": {
+                    "name": {
+                        "type": "text",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_10_0"
+                        ]
+                    },
+                    "name_edgengrams": {
+                        "type": "text",
+                        "analyzer": "edgengram_analyzer",
+                        "search_analyzer": "standard"
+                    }
+                }
+            },
+            "uploaded_by_user_id_filter": {
+                "type": "integer"
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_10_0": {
+                "type": "text"
+            }
+        }
+    },
+    "<class 'wagtail.models.Page'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title": {
+                "type": "text",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_2_0"
+                ]
+            },
+            "title_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "id_filter": {
+                "type": "integer"
+            },
+            "live_filter": {
+                "type": "boolean"
+            },
+            "owner_id_filter": {
+                "type": "integer"
+            },
+            "content_type_id_filter": {
+                "type": "integer"
+            },
+            "path_filter": {
+                "type": "keyword"
+            },
+            "depth_filter": {
+                "type": "integer"
+            },
+            "locked_filter": {
+                "type": "boolean"
+            },
+            "show_in_menus_filter": {
+                "type": "boolean"
+            },
+            "first_published_at_filter": {
+                "type": "date"
+            },
+            "last_published_at_filter": {
+                "type": "date"
+            },
+            "latest_revision_created_at_filter": {
+                "type": "date"
+            },
+            "locale_id_filter": {
+                "type": "integer"
+            },
+            "translation_key_filter": {
+                "type": "keyword"
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_2_0": {
+                "type": "text"
+            }
+        }
+    },
+    "<class 'wagtailmedia.models.Media'>": {
+        "properties": {
+            "pk": {
+                "type": "keyword",
+                "store": true
+            },
+            "content_type": {
+                "type": "keyword"
+            },
+            "_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "collection_id_filter": {
+                "type": "integer"
+            },
+            "title": {
+                "type": "text",
+                "copy_to": [
+                    "_all_text",
+                    "_all_text_boost_10_0"
+                ]
+            },
+            "title_edgengrams": {
+                "type": "text",
+                "analyzer": "edgengram_analyzer",
+                "search_analyzer": "standard"
+            },
+            "title_filter": {
+                "type": "keyword"
+            },
+            "tags": {
+                "type": "nested",
+                "properties": {
+                    "name": {
+                        "type": "text",
+                        "copy_to": [
+                            "_all_text",
+                            "_all_text_boost_10_0"
+                        ]
+                    },
+                    "name_edgengrams": {
+                        "type": "text",
+                        "analyzer": "edgengram_analyzer",
+                        "search_analyzer": "standard"
+                    }
+                }
+            },
+            "uploaded_by_user_id_filter": {
+                "type": "integer"
+            },
+            "_all_text": {
+                "type": "text"
+            },
+            "_all_text_boost_10_0": {
+                "type": "text"
+            }
+        }
+    }
+}

--- a/src/extended_search/tests/test_indexed.py
+++ b/src/extended_search/tests/test_indexed.py
@@ -10,10 +10,6 @@ from content.models import BasePage, BlogIndex, BlogPost, ContentPage, Navigatio
 from core.models.tags import Tag
 from country_fact_sheet.models import CountryFactSheetHome
 from extended_search.index import DWIndexedField, class_is_indexed, get_indexed_models
-from extended_search.management.commands.create_index_fields_json import (
-    JSON_FILE,
-    get_indexed_models_and_fields_dict,
-)
 from home.models import HomePage
 from networks.models import Network, NetworksHome
 from news.models import NewsHome, NewsPage
@@ -276,6 +272,11 @@ class TestProject:
         }, "Indexed models have changed, please update this test if this was intentional."
 
     def test_indexed_models_and_fields(test):
+        from extended_search.management.commands.create_index_fields_json import (
+            JSON_FILE,
+            get_indexed_models_and_fields_dict,
+        )
+
         with open(JSON_FILE, "r") as f:
             expected_indexed_models_and_fields = json.load(f)
             assert (
@@ -285,4 +286,18 @@ class TestProject:
                 "Indexed models and fields have changed."
                 " If this was intentional, please update the JSON file by running the"
                 " `create_index_fields_json` management command."
+            )
+
+    def test_indexed_mappings(test):
+        from extended_search.management.commands.create_index_mapping_json import (
+            JSON_FILE,
+            get_indexed_mapping_dict,
+        )
+
+        with open(JSON_FILE, "r") as f:
+            expected_indexed_mapping = json.load(f)
+            assert get_indexed_mapping_dict() == expected_indexed_mapping, (
+                "Indexed mappings have changed."
+                " If this was intentional, please update the JSON file by running the"
+                " `create_index_mapping_json` management command."
             )


### PR DESCRIPTION
This PR aims to improve the search index update logic to reduce the risk of downtime.
Search downtime will still happen with these changes, but the goal is to reduce the likelihood of it happening, and when it does happen, we inform the user more gracefully.

## The current issues
Running a schema only update while also using an atomic rebuild process results in an empty index being pushed. The Wagtail documentation doesn't warn users of this behaviour, but it appears that this is what is happening.
Not running a schema only update results in our search views returning 500 errors as the mapping of the documents doesn't match the expected mapping of our code, resulting in the query failing.

## Proposed solution
We update the logic so that we no longer do a schema only update, this will result in 500 errors.
We catch the error and raise a nicer more user friendly message that says something along the lines of "Search is currently down, it should be back up in X minutes" etc.
We reduce the likelihood of users seeing this on deployment, by only running the update index command on deployments that we think NEED the index updating.

The outcome of this will be that deployments that change search mappings will result in an update index and users seeing an error message (a much nicer error message). However, most deployments shouldn't effect the search at all.

## Changes made so far:
 - [x] No more schema only updates
 - [ ] Catch the search error and return a nicer error message to the user
 - [x] Only update search on deployments that alter the mapping
