### PR TITLE
Fix the search results to include the excerpt

### DIFF
--- a/src/search/search.py
+++ b/src/search/search.py
@@ -53,7 +53,7 @@ class ModelSearchVector(SearchVector):
 
 class PagesSearchVector(ModelSearchVector):
     def get_queryset(self):
-        return super().get_queryset().public_or_login().live()
+        return super().get_queryset().public_or_login().live().specific()
 
     def pinned(self, query_str):
         return self.get_queryset().pinned(query_str)


### PR DESCRIPTION
Return the specific page models so we have access to `.excerpt`