### PR TITLE
Update site to style the page/sidebar closer to the new styles

### DIFF
--- a/assets/stylesheets/components/_content_page.scss
+++ b/assets/stylesheets/components/_content_page.scss
@@ -1,7 +1,11 @@
-.content_page {
+.content_page .primary-content {
   padding: var(--space);
   background-color: var(--color-background);
   border-radius: var(--border-radius);
+
+  h1 {
+    margin-top: 0;
+  }
 }
 
 .ws-content-page__metadata {

--- a/src/core/templates/dwds_content.html
+++ b/src/core/templates/dwds_content.html
@@ -13,16 +13,11 @@
             <div class="stack">
                 {% block pre_content %}
                 {% endblock pre_content %}
-                {% block page_title %}
-                    <h1>{{ page.title }}</h1>
-                {% endblock page_title %}
-                {% block bookmark %}
-                    {% if FEATURE_FLAGS.new_homepage and page %}
-                        <div class="dwds">{% bookmark_page_input user page %}</div>
-                    {% endif %}
-                {% endblock bookmark %}
                 <div class="with-sidebar-right">
                     <div class="primary-content">
+                        {% block page_title %}
+                            <h1>{{ page.title }}</h1>
+                        {% endblock page_title %}
                         {% block pre_primary_content %}
                         {% endblock pre_primary_content %}
                         {% block primary_content %}
@@ -32,6 +27,11 @@
                         {% endblock post_primary_content %}
                     </div>
                     <div class="secondary-content">
+                        {% block bookmark %}
+                            {% if FEATURE_FLAGS.new_homepage and page %}
+                                {% bookmark_page_input user page %}
+                            {% endif %}
+                        {% endblock bookmark %}
                         {% block pre_secondary_content %}
                         {% endblock pre_secondary_content %}
                         {% block secondary_content %}

--- a/src/interactions/templates/interactions/bookmark_page_input.html
+++ b/src/interactions/templates/interactions/bookmark_page_input.html
@@ -1,15 +1,30 @@
-{% if page %}
-    <button class="bookmark-page-input"
-            title="{{ is_bookmarked|yesno:'Remove bookmark,Bookmark this page' }}"
-            data-is-htmx="{{ request.headers.hx_request }}"
-            hx-post="{{ post_url }}"
-            hx-vals='{"page_id": {{ page.id }}}'
-            hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-            hx-trigger="click"
-            hx-select="button"
-            hx-target="this"
-            hx-swap="outerHTML">
-        {% include 'dwds/elements/icon.html' with id='bookmark-icon' is_filled=is_bookmarked %}
-        <span>{{ is_bookmarked|yesno:'Bookmarked,Bookmark' }}</span>
-    </button>
-{% endif %}
+{% extends "dwds/elements/extendable/card.html" %}
+
+{% block card_container_classes %}dwds-card-white{% endblock %}
+
+{% block card_header %}
+{% endblock card_header %}
+
+{% block card_content_image %}
+{% endblock card_content_image %}
+
+{% block card_content_body %}
+    {% if page %}
+        <button class="bookmark-page-input"
+                title="{{ is_bookmarked|yesno:'Remove bookmark,Bookmark this page' }}"
+                data-is-htmx="{{ request.headers.hx_request }}"
+                hx-post="{{ post_url }}"
+                hx-vals='{"page_id": {{ page.id }}}'
+                hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                hx-trigger="click"
+                hx-select="button"
+                hx-target="this"
+                hx-swap="outerHTML">
+            {% include 'dwds/elements/icon.html' with id='bookmark-icon' is_filled=is_bookmarked %}
+            <span>{{ is_bookmarked|yesno:'Bookmarked,Bookmark' }}</span>
+        </button>
+    {% endif %}
+{% endblock card_content_body %}
+
+{% block card_footer %}
+{% endblock card_footer %}

--- a/src/news/templates/news/includes/news_categories_new.html
+++ b/src/news/templates/news/includes/news_categories_new.html
@@ -1,0 +1,10 @@
+<nav aria-labelledby="news-category-heading">
+    <h3 id="news-category-heading">All news categories</h3>
+    <ul>
+        {% for category in categories %}
+            <li>
+                <a href="/news-and-views/category/{{ category.slug }}">{{ category.category }}</a>
+            </li>
+        {% endfor %}
+    </ul>
+</nav>

--- a/src/news/templates/news/news_home_new.html
+++ b/src/news/templates/news/news_home_new.html
@@ -61,5 +61,5 @@
 {% endblock primary_content %}
 
 {% block secondary_content %}
-    {% include "news/includes/news_categories.html" %}
+    {% include "news/includes/news_categories_new.html" %}
 {% endblock secondary_content %}

--- a/src/news/templates/news/news_page_new.html
+++ b/src/news/templates/news/news_page_new.html
@@ -111,5 +111,5 @@
 {% endblock post_primary_content %}
 
 {% block secondary_content %}
-    {% include "news/includes/news_categories.html" %}
+    {% include "news/includes/news_categories_new.html" %}
 {% endblock secondary_content %}


### PR DESCRIPTION
Just a small update to bring in the page/sidebar styles as it exists in the designs
![Screenshot 2024-08-23 at 12 45 25](https://github.com/user-attachments/assets/6b2fb8d5-255c-4a84-957d-bb4c778ceb74)

**Initial thoughts:**
- With the bookmark in the sidebar, it moves to the bottom of the page for narrow screens (mobiles). Which doesn't feel ideal.
- The `bookmark_page_input` template currently is a hacky extension of the base card component, this should be updated to a generic component to meet the designs (see below)

![Screenshot 2024-08-23 at 12 50 04](https://github.com/user-attachments/assets/077f9328-5039-4d83-8a5c-2d3fd4b5f45e)
