### PR TITLE
DWDS Update text sizing and styles page

### DIFF
--- a/src/dw_design_system/dwds/components/banner_card.scss
+++ b/src/dw_design_system/dwds/components/banner_card.scss
@@ -3,7 +3,7 @@
 
     h3 {
         color: var(--color-text-highlight);
-        font-size: var(--s1);
+        font-size: var(--text-xlarge);
         font-weight: var(--font-weight-normal);
         line-height: var(--font-lineheight-headings);
     }

--- a/src/dw_design_system/dwds/elements/extendable/card.scss
+++ b/src/dw_design_system/dwds/elements/extendable/card.scss
@@ -41,7 +41,7 @@
         color: var(--header-text-colour);
 
         .card-subtitle {
-            font-size: var(--s0);
+            font-size: var(--text-large);
         }
 
         h2,
@@ -72,7 +72,7 @@
             .card-body {
                 flex-grow: 1;
                 padding: var(--s0);
-                font-size: var(--s0);
+                font-size: var(--text-large);
                 line-height: var(--font-lineheight-body);
 
                 h2,

--- a/src/dw_design_system/dwds/elements/navigational_link.scss
+++ b/src/dw_design_system/dwds/elements/navigational_link.scss
@@ -3,7 +3,7 @@
     justify-content: space-between;
     color: var(--color-link);
     font-family: var(--font-family-primary);
-    font-size: var(--s1);
+    font-size: var(--text-xlarge);
     font-weight: var(--font-weight-normal);
     line-height: var(--font-lineheight-headings);
     text-decoration: none;

--- a/src/dw_design_system/dwds/styles/temporary-base.scss
+++ b/src/dw_design_system/dwds/styles/temporary-base.scss
@@ -48,15 +48,15 @@ body {
     }
 
     h1 {
-        font-size: var(--s3);
+        font-size: var(--text-xxxlarge);
     }
 
     h2 {
-        font-size: var(--s2);
+        font-size: var(--text-xxlarge);
     }
 
     h3 {
-        font-size: var(--s1);
+        font-size: var(--text-xlarge);
     }
 
     a {
@@ -64,7 +64,8 @@ body {
     }
 
     // Using !important to have consistent focus/active states on all links
-    a:focus, a:active {
+    a:focus,
+    a:active {
         text-decoration: underline var(--text-underline-hover) !important;
         background-color: var(--color-link-background-active) !important;
         color: var(--color-text) !important;

--- a/src/dw_design_system/dwds/styles/typography.scss
+++ b/src/dw_design_system/dwds/styles/typography.scss
@@ -26,7 +26,3 @@
   font-weight: var(--font-weight-normal);
   font-style: italic;
 }
-
-.text-small {
-  font-size: var(--s-1);
-}

--- a/src/dw_design_system/dwds/styles/variables.scss
+++ b/src/dw_design_system/dwds/styles/variables.scss
@@ -2,8 +2,8 @@
   --page-width: 1250px;
 
   // Brand colours - for re-use in this file only
-  --dbt-blue: #00285F;
   --dbt-red: #CF102D;
+  --dbt-blue: #00285F;
   --dbt-light-blue: #0063BE;
   --dbt-light-blue-rgb: 0, 99, 190;
 
@@ -68,6 +68,14 @@
   --padding-button: 11px 20px 11px;
   --padding-button-inline: 6px 15px 5px;
   --card-comment-section-margin-top: 8px;
+
+  // Text size
+  --text-small: var(--s-2);
+  --text-medium: var(--s-1);
+  --text-large: var(--s0);
+  --text-xlarge: var(--s1);
+  --text-xxlarge: var(--s2);
+  --text-xxxlarge: var(--s3);
 
   // Borders and element widths
   --border-width: 3px;

--- a/src/dw_design_system/dwds/unsure/ribbon.scss
+++ b/src/dw_design_system/dwds/unsure/ribbon.scss
@@ -3,14 +3,13 @@
     --ribbon-background-red: var(--dbt-red);
     --ribbon-padding: var(--s-4);
     --ribbon-padding-right: var(--s-2);
-    --ribbon-text-height: var(--s1);
     --ribbon-left-space: calc(var(--space) + calc(var(--space) / 2));
     --ribbon-text-colour: var(--card-white);
     --ribbon-line-height: var(--font-lineheight-headings);
     --ribbon-height: calc(var(--ribbon-padding) + var(--ribbon-padding) + var(--ribbon-line-height));
 
     display: inline-block;
-    font-size: var(--ribbon-text-height);
+    font-size: var(--text-xlarge);
     font-weight: var(--font-weight-bold);
 
     .ribbon-main,

--- a/src/dw_design_system/templates/dw_design_system/styles.html
+++ b/src/dw_design_system/templates/dw_design_system/styles.html
@@ -1,7 +1,7 @@
 {% extends "dwds_content.html" %}
 
 {% block title %}
-    DW Design System components
+    DW Design System styles
 {% endblock title %}
 
 {% block page_title %}

--- a/src/dw_design_system/templates/dw_design_system/styles.html
+++ b/src/dw_design_system/templates/dw_design_system/styles.html
@@ -5,13 +5,89 @@
 {% endblock title %}
 
 {% block page_title %}
+    <br />
     <h1>DW Design System styles</h1>
 {% endblock page_title %}
 
 {% block primary_content %}
     <h1>Styles</h1>
 
+    <h2>Spacing</h2>
+
+    <div style="display: grid; grid-template-columns: 1fr 3fr">
+        {% for s in spaces %}
+            <span>{{ s }}</span>
+            <div style="width: 100%;
+                        border: 1px solid black;
+                        height: var({{ s }});
+                        margin: 5px 0px"></div>
+        {% endfor %}
+    </div>
+
+    <h2>Typography</h2>
+
+    {% for ts in text_sizes %}
+        <span style="font-size: var({{ ts }});">{{ ts }}</span>
+        <br>
+    {% endfor %}
+
+    <h1>Heading 1</h1>
+    <h2>Heading 2</h2>
+    <h3>Heading 3</h3>
+    <h4>Heading 4</h4>
+    <h5>Heading 5</h5>
+    <h6>Heading 6</h6>
+
+    <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce condimentum feugiat odio, eu interdum odio commodo a. Ut sollicitudin, nisi non tempor bibendum, justo eros tincidunt urna, at rhoncus dui ante sed urna. Aenean sed nisi vitae dui sagittis iaculis vitae quis nulla. Vivamus malesuada, massa id semper mollis, dolor tellus vehicula mi, ut posuere lacus justo vel velit. Nulla at consectetur ipsum. Nam dui massa, dignissim non vulputate nec, rutrum mollis magna. Duis nec facilisis massa.
+    </p>
+    <p>
+        <b>
+            Lorem ipsum dolor sit amet
+        </b>
+    </p>
+    <p>
+        <i>
+            Lorem ipsum dolor sit amet
+        </i>
+    </p>
+    <p>
+        <q>
+            Lorem ipsum dolor sit amet
+        </q>
+    </p>
+    <blockquote>
+        Lorem ipsum dolor sit amet
+    </blockquote>
+
+    <a href="#">Lorem ipsum dolor sit amet</a>
+
+    <ul>
+        <li>Item 1</li>
+        <li>Item 2</li>
+        <li>Item 3</li>
+    </ul>
+
+    <ol>
+        <li>Item 1</li>
+        <li>Item 2</li>
+        <li>Item 3</li>
+    </ol>
+
+    <hr>
+
+    <h2>Colors</h2>
+
+    {% for colour in colours %}
+        <span>{{ colour }}</span>
+        <div style="width: 100%;
+                    height: 50px;
+                    margin: 5px 0px;
+                    background-color: var({{ colour }})"></div>
+    {% endfor %}
+
     <h2>Buttons</h2>
+
     <div style="display: flex; gap: 1rem; margin-bottom: 1rem;">
         <button class="dwds-button">Primary button</button>
         <button class="dwds-button dwds-button--secondary">Secondary button</button>
@@ -27,15 +103,4 @@
         <button class="dwds-button dwds-button--transactional dwds-button--inline">TB (inline)</button>
     </div>
 
-    <h2>Headings (examples, these styles don't exist yet)</h2>
-
-    <span class="dwds-heading-xl">Heading XL</span>
-    <br>
-    <span class="dwds-heading-l">Heading L</span>
-    <br>
-    <span class="dwds-heading-m">Heading M</span>
-    <br>
-    <span class="dwds-heading-s">Heading S</span>
-    <br>
-    <span class="dwds-heading-xs">Heading XS</span>
 {% endblock primary_content %}

--- a/src/dw_design_system/views.py
+++ b/src/dw_design_system/views.py
@@ -8,10 +8,40 @@ from dw_design_system.utils import CustomJSONDecoder, get_components, to_json
 
 
 def styles(request: HttpRequest) -> HttpResponse:
+    context = {
+        "colours": [
+            "--gds-red",
+            "--dbt-red",
+            "--dbt-blue",
+            "--dbt-light-blue",
+        ],
+        "spaces": [
+            "--s5",
+            "--s4",
+            "--s3",
+            "--s2",
+            "--s1",
+            "--s0",
+            "--s-1",
+            "--s-2",
+            "--s-3",
+            "--s-4",
+            "--s-5",
+        ],
+        "text_sizes": [
+            "--text-xxxlarge",
+            "--text-xxlarge",
+            "--text-xlarge",
+            "--text-large",
+            "--text-medium",
+            "--text-small",
+        ],
+    }
+
     return render(
         request,
         "dw_design_system/styles.html",
-        {},
+        context,
     )
 
 


### PR DESCRIPTION
Update headings so that we now have text size variables.
Update the DWDS styles page so that it highlights the basic styling of the new system

![image](https://github.com/user-attachments/assets/0a7736d4-b3da-4f64-805a-7aa52f8aaf8b)
