### PR TITLE
INTR-332 Fix ribbon styling

### DIFF
--- a/src/config/settings/base.py
+++ b/src/config/settings/base.py
@@ -299,6 +299,10 @@ STATICFILES_FINDERS = [
 
 STATICFILES_DIRS = [
     os.path.join(PROJECT_ROOT_DIR, "assets"),
+    (
+        "dwds",
+        os.path.join(PROJECT_ROOT_DIR, "src", "dw_design_system", "dwds"),
+    ),
 ]
 
 STATIC_ROOT = os.path.join(PROJECT_ROOT_DIR, "static")

--- a/src/core/templates/dwds_content.html
+++ b/src/core/templates/dwds_content.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
 {% load bookmarks %}
+{% load static %}
 
 {% block body_classes %}dwds-body{% endblock %}
 
@@ -46,3 +47,7 @@
             </div>
         </div>
     {% endblock main_content %}
+
+    {% block scripts %}
+        <script src='{% static "dwds/elements/ribbon.js" %}'></script>
+    {% endblock scripts %}

--- a/src/dw_design_system/dwds/elements/ribbon.html
+++ b/src/dw_design_system/dwds/elements/ribbon.html
@@ -1,4 +1,4 @@
 <div class="dwds-ribbon">
     <div class="ribbon-main {% if colour %}ribbon-{{ colour }}{% endif %}">{{ text }}</div>
-    <div class="ribbon-spacer">{{ text }}</div>
+    <div class="ribbon-spacer"></div>
 </div>

--- a/src/dw_design_system/dwds/elements/ribbon.html
+++ b/src/dw_design_system/dwds/elements/ribbon.html
@@ -1,4 +1,4 @@
 <div class="dwds-ribbon">
-    <div class="ribbon-spacer"></div>
     <div class="ribbon-main {% if colour %}ribbon-{{ colour }}{% endif %}">{{ text }}</div>
+    <div class="ribbon-spacer">{{ text }}</div>
 </div>

--- a/src/dw_design_system/dwds/elements/ribbon.js
+++ b/src/dw_design_system/dwds/elements/ribbon.js
@@ -12,6 +12,4 @@ window.addEventListener('resize', () => {
     ribbons.forEach(resizeSpacer);
 });
 
-ribbons.forEach(ribbon => {
-    resizeSpacer(ribbon);
-});
+ribbons.forEach(resizeSpacer);

--- a/src/dw_design_system/dwds/elements/ribbon.js
+++ b/src/dw_design_system/dwds/elements/ribbon.js
@@ -9,9 +9,7 @@ function resizeSpacer(ribbon) {
 }
 
 window.addEventListener('resize', () => {
-    ribbons.forEach(ribbon => {
-        resizeSpacer(ribbon);
-    });
+    ribbons.forEach(resizeSpacer);
 });
 
 ribbons.forEach(ribbon => {

--- a/src/dw_design_system/dwds/elements/ribbon.js
+++ b/src/dw_design_system/dwds/elements/ribbon.js
@@ -1,0 +1,19 @@
+const ribbons = document.querySelectorAll('.dwds-ribbon');
+
+function resizeSpacer(ribbon) {
+    const ribbonMain = ribbon.querySelector('.ribbon-main');
+    const ribbonSpacer = ribbon.querySelector('.ribbon-spacer');
+
+    ribbonSpacer.style.height = ribbonMain.clientHeight + 'px';
+    ribbonSpacer.style.width = ribbonMain.clientWidth + 'px';
+}
+
+window.addEventListener('resize', () => {
+    ribbons.forEach(ribbon => {
+        resizeSpacer(ribbon);
+    });
+});
+
+ribbons.forEach(ribbon => {
+    resizeSpacer(ribbon);
+});

--- a/src/dw_design_system/dwds/elements/ribbon.scss
+++ b/src/dw_design_system/dwds/elements/ribbon.scss
@@ -16,16 +16,19 @@
     .ribbon-main,
     .ribbon-spacer {
         min-height: var(--ribbon-height);
-        padding: var(--ribbon-padding) var(--ribbon-padding-right) var(--ribbon-padding) var(--ribbon-left-space);        
+        padding: var(--ribbon-padding) var(--ribbon-padding-right) var(--ribbon-padding) var(--ribbon-left-space);
         margin-left: calc(var(--ribbon-left-space) * -1);
+        border-radius: var(--ribbon-border-radius);
     }
 
     .ribbon-main {
-        margin-top: calc(var(--ribbon-height) * -1);
         color: var(--ribbon-text-colour);
         background: var(--ribbon-background-blue);
         position: absolute;
-        border-radius: var(--ribbon-border-radius);
+    }
+
+    .ribbon-spacer {
+        visibility: hidden;
     }
 
     .ribbon-red {


### PR DESCRIPTION
The ribbon styling is a little odd this PR simplifies the spacer logic.

Issues still remaining:
- [x] When a ribbon has text that is long (`Diversity and inclusion`) it wraps earlier in the spacer than it does in the "main". This looks to be related to the position absolute and I can't wrap my head around it (see GIF below)

![ribbon](https://github.com/user-attachments/assets/32d0be3e-ecec-4cbb-9c72-aef10c9bf147)
