### PR TITLE
Fix OSX docker DNS settings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,8 @@ services:
       - ./:/app/
     ports:
       - "0.0.0.0:8000:8000"
+    dns:
+      - 0.0.0.0
     depends_on:
       - db
       - redis


### PR DESCRIPTION
With the new OSX Sequoia update, requests from within the Docker image can't resolve hostnames.
This aims to fix that issue.