### PR TITLE
Revert DNS change in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,8 +66,6 @@ services:
       - ./:/app/
     ports:
       - "0.0.0.0:8000:8000"
-    dns:
-      - 0.0.0.0
     depends_on:
       - db
       - redis


### PR DESCRIPTION
This change is no longer needed, the issue was caused by a security rule blocking the firewall and this "workaround" just causes more issues in other areas.