### PR TITLE
Fix ribbon width

### DIFF
--- a/src/dw_design_system/dwds/elements/ribbon.scss
+++ b/src/dw_design_system/dwds/elements/ribbon.scss
@@ -18,6 +18,7 @@
         border-radius: var(--ribbon-border-radius);
         color: var(--ribbon-text-colour);
         background: var(--ribbon-background-blue);
+        width: fit-content;
     }
 
     .ribbon-red {


### PR DESCRIPTION
Make sure the ribbon is only as wide as it needs to be.

Before:
![Screenshot 2024-09-20 at 10 46 48](https://github.com/user-attachments/assets/37dc5478-5d3d-4c38-8774-e17e94433c0d)

After:
![Screenshot 2024-09-20 at 10 47 11](https://github.com/user-attachments/assets/7aeb9861-0ae5-440c-b642-ef8fb2c8d59f)
