### PR TITLE
INTR-346 Home priority page order bug

### DIFF
--- a/src/core/panels.py
+++ b/src/core/panels.py
@@ -1,0 +1,11 @@
+from wagtail.admin.panels import PageChooserPanel
+
+from core.widgets import ReadOnlyPageInput
+
+
+class PageSelectorPanel(PageChooserPanel):
+    class BoundPanel(PageChooserPanel.BoundPanel):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            if self.instance.pk:
+                self.bound_field.field.widget = ReadOnlyPageInput()

--- a/src/core/panels.py
+++ b/src/core/panels.py
@@ -7,5 +7,5 @@ class PageSelectorPanel(PageChooserPanel):
     class BoundPanel(PageChooserPanel.BoundPanel):
         def __init__(self, **kwargs):
             super().__init__(**kwargs)
-            if self.instance.pk:
+            if self.instance and self.instance.pk:
                 self.bound_field.field.widget = ReadOnlyPageInput()

--- a/src/core/templates/core/forms/widgets/readonly_page.html
+++ b/src/core/templates/core/forms/widgets/readonly_page.html
@@ -1,0 +1,2 @@
+{% include "django/forms/widgets/hidden.html" %}
+{% include "wagtailadmin/panels/read_only_output.html" %}

--- a/src/core/widgets.py
+++ b/src/core/widgets.py
@@ -1,0 +1,14 @@
+from django.forms import HiddenInput
+from wagtail.models import Page
+
+
+class ReadOnlyPageInput(HiddenInput):
+    template_name = "core/forms/widgets/readonly_page.html"
+
+    def get_context(self, name, value, attrs):
+        context = super().get_context(name, value, attrs)
+        context.update(
+            display_value=Page.objects.get(id=value).title,
+            id_for_label=attrs.get("id", None),
+        )
+        return context

--- a/src/home/models.py
+++ b/src/home/models.py
@@ -14,7 +14,6 @@ from wagtail.admin.panels import (
     FieldPanel,
     InlinePanel,
     MultiFieldPanel,
-    PageChooserPanel,
 )
 from wagtail.models import PagePermissionTester
 from wagtail.snippets.models import register_snippet
@@ -24,6 +23,7 @@ from wagtailorderable.models import Orderable
 from content.models import BasePage, ContentPage
 from core.models import fields
 from core.models.models import SiteAlertBanner
+from core.panels import PageSelectorPanel
 from events.models import EventPage
 from home.forms import HomePageForm
 from home.validators import validate_home_priority_pages
@@ -96,7 +96,7 @@ class HomePriorityPage(Orderable):
     )
 
     panels = [
-        PageChooserPanel("page", HOME_PRIORITY_PAGE_TYPES),
+        PageSelectorPanel("page", HOME_PRIORITY_PAGE_TYPES),
         FieldPanel("ribbon_text"),
     ]
 


### PR DESCRIPTION
This PR adds a new panel type for selecting a page and preventing the ability to edit the page once it's set. A "Page Selector" instead of a "Page Chooser".

![priority_pages](https://github.com/user-attachments/assets/1ec77d43-4028-4f35-8619-6a2795b72998)

As you can see in the GIF above, the behaviour is as follows:
- Adding a new priority page allows for:
  - Selecting a page
  - Removing the page
  - Choosing a different page
- After saving the page as a draft you can still:
  - Selecting a page
  - Removing the page
  - Choosing a different page
- After publishing a page you can no longer change the page, you have to delete the priority page item and create a new instance

- [x] JIRA ticket referenced in title
- [x] Title is clear and concise
- [x] Description gives any relevant detail
- [x] Tests are up to date
- [x] Documentation is up to date

