### PR TITLE
Changed active ancestor to govuk-link-visited-colour

### DIFF
--- a/assets/stylesheets/govuk-overrides/header.scss
+++ b/assets/stylesheets/govuk-overrides/header.scss
@@ -193,7 +193,7 @@
         &:link,
         &:hover,
         &:visited {
-            color: govuk-colour("white");
+            color: $govuk-link-visited-colour;
         }
 
         &:focus {


### PR DESCRIPTION
- [x] JIRA ticket referenced in title
- [x] Title is clear and concise
- [x] Description gives any relevant detail
- [x] Tests are up to date
- [x] Documentation is up to date

Changed the color of header navigation ancestors to [$govuk-link-visited-colour ](https://design-system.service.gov.uk/styles/colour/).