### PR TITLE
Cards in a content list grid shouldn't have the rounded corners

### DIFF
--- a/src/dw_design_system/dwds/components/content_list.scss
+++ b/src/dw_design_system/dwds/components/content_list.scss
@@ -27,6 +27,11 @@
             .content-main {
                 --content-main-padding: var(--s0);
             }
+
+            .content-image {
+                height: auto;
+                border-radius: unset;
+            }
         }
     }
 }

--- a/src/home/templates/home/home_page.html
+++ b/src/home/templates/home/home_page.html
@@ -59,11 +59,7 @@
 
                 {% if events %}
                     <div class="dwds-content-item-card no-shadow">
-                        {% if FEATURE_FLAGS.event_listing %}
-                            {% include "dwds/components/content_list.html" with as_card_grid=True highlight=True title="Events" content_items=events link_url="/events/" link_text="View all events" %}
-                        {% else %}
-                            {% include "dwds/components/content_list.html" with as_card_grid=True highlight=True title="Events" content_items=events %}
-                        {% endif %}
+                        {% include "dwds/components/content_list.html" with as_card_grid=True highlight=True title="Events" content_items=events link_url="/events/" link_text="View all events" %}
                     </div>
                 {% endif %}
 


### PR DESCRIPTION
I spotted this after reviewing the recent changes on staging:

![Screenshot 2024-10-09 at 15 18 35](https://github.com/user-attachments/assets/13f5115c-af77-4adb-bd04-f3d859212151)

It might be hard to see, but in the image above, the image has rounded corners. This only happens in the content list when displayed as a grid.

![Screenshot 2024-10-09 at 15 19 21](https://github.com/user-attachments/assets/1b82ca7e-179f-49ad-96f7-0a57f2f1363e)

The behaviour is wanted in a content list when displayed as a vertical list:

![Screenshot 2024-10-09 at 15 20 24](https://github.com/user-attachments/assets/a0d21af7-a2af-48ca-b047-90e2c26efd48)

This PR fixes this issue by resetting the images styling only in the grid scenario:

![Screenshot 2024-10-09 at 15 21 15](https://github.com/user-attachments/assets/e9f49e94-87ec-4d16-b161-7db4de12d578)
