### PR TITLE
Revert content images to have a max-inline-size

### DIFF
--- a/src/dw_design_system/dwds/styles/temporary-base.scss
+++ b/src/dw_design_system/dwds/styles/temporary-base.scss
@@ -29,7 +29,6 @@ body {
 
     article,
     div,
-    figure,
     footer,
     form,
     header,


### PR DESCRIPTION
This PR reverts a change that was made to make images in content expand to the full available space.

Images in content got too large and we should address the image sizing alongside the rest of the streamfield content in a future ticket.

Examples:
![Screenshot 2024-10-10 at 12 05 32](https://github.com/user-attachments/assets/3432ab13-a02c-47b6-ba53-9a1e7505e212)
![Screenshot 2024-10-10 at 12 05 42](https://github.com/user-attachments/assets/2178adef-4e2b-4c9b-9458-76832db45b07)
