### PR TITLE
Cache search counts

### DIFF
--- a/src/search/templatetags/search.py
+++ b/src/search/templatetags/search.py
@@ -136,8 +136,8 @@ def get_count(context, category, query):
     request = context["request"]
 
     cache_key = f"{category}_{query}"
-    cache_value = cache.get(cache_key)
-    if cache_value:
+    cache_value = cache.get(cache_key, None)
+    if cache_value is not None:
         return cache_value
 
     search_vector = SEARCH_VECTORS[category](request)

--- a/src/search/templatetags/search.py
+++ b/src/search/templatetags/search.py
@@ -138,7 +138,7 @@ def get_count(context, category, query):
     if not hasattr(request, "extended_search_count_cache"):
         request.extended_search_count_cache = {}
 
-    cached_count = request.search_count_cache.get(category, None)
+    cached_count = request.extended_search_count_cache.get(category, None)
     if cached_count is not None:
         return cached_count
 

--- a/src/search/templatetags/search.py
+++ b/src/search/templatetags/search.py
@@ -135,20 +135,17 @@ def autocomplete(request, query):
 def get_count(context, category, query):
     request = context["request"]
 
-    cache_key = f"{category}_{query}"
-    cache_value = cache.get(cache_key, None)
-    if cache_value is not None:
-        return cache_value
+    if not hasattr(request, "extended_search_count_cache"):
+        request.extended_search_count_cache = {}
+
+    cached_count = request.search_count_cache.get(category, None)
+    if cached_count is not None:
+        return cached_count
 
     search_vector = SEARCH_VECTORS[category](request)
     hits = search_vector.search(query).count()
 
-    # Cache the result for 5s as it is only useful for this request.
-
-    # DEV NOTE (remove before merge):
-    # There's the possibility that someone makes the same query in the same
-    # time, but if so, the count is likely the same so it's not a big issue.
-    cache.set(cache_key, hits, 5)
+    request.extended_search_count_cache[category] = hits
     return hits
 
 

--- a/src/search/templatetags/search.py
+++ b/src/search/templatetags/search.py
@@ -2,7 +2,6 @@ from typing import Literal, Tuple
 
 from django import template
 from django.conf import settings
-from django.core.cache import cache
 from django.core.paginator import Paginator
 
 from search import search as search_vectors


### PR DESCRIPTION
This PR is mainly for discussion and possibly a quick win.

Caching the counts for a short period will mean that we don't need to perform multiple queries to Open Search for data that we have already pulled moments ago.

- The all search result page currently performs 15 OS requests
- The Individual category pages perform 9 OS requests

With this caching in place, that should be reduced to:

- The all search result page currently performs 9 OS requests
- The Individual category pages perform 7 OS requests

Locally the improvements are night and day!