### PR TITLE
[Poc] iCal subscribe progress

### DIFF
--- a/src/config/settings/base.py
+++ b/src/config/settings/base.py
@@ -593,6 +593,7 @@ DLFA_INCLUDE_RAW_LOG = True
 
 # Remove SSO protection from health check and Hawk authed URLs
 AUTHBROKER_ANONYMOUS_PATHS = (
+    "/ical/all/",
     "/pingdom/ping.xml",
     "/peoplefinder/api/activity-stream/",
     "/peoplefinder/api/person-api/",

--- a/src/config/settings/developer.py
+++ b/src/config/settings/developer.py
@@ -1,4 +1,15 @@
+import environ
+import os
+
 from .base import *  # noqa
+
+
+# Read environment variables using `django-environ`, use `.env` if it exists
+env = environ.Env()
+env_file = os.path.join(PROJECT_ROOT_DIR, ".env")
+if os.path.exists(env_file):
+    env.read_env(env_file)
+env.read_env()
 
 DEBUG = True
 
@@ -38,7 +49,7 @@ except ModuleNotFoundError:
     ...
 
 
-DEV_TOOLS_ENABLED = True
+DEV_TOOLS_ENABLED = env.bool("DEV_TOOLS_ENABLED", True)
 
 if DEV_TOOLS_ENABLED:
     # remove Django Staff SSO Client for local login

--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -12,7 +12,7 @@ from wagtail.documents import urls as wagtaildocs_urls
 from core.admin import admin_site
 from core.urls import urlpatterns as core_urlpatterns
 from dw_design_system.urls import urlpatterns as dwds_urlpatterns
-from events.views import ical_feed
+from events.views import ical_feed, ical_links
 from peoplefinder.urls import api_urlpatterns, people_urlpatterns, teams_urlpatterns
 
 
@@ -53,6 +53,7 @@ urlpatterns = [
     # DW Design System
     path("dwds/", include(dwds_urlpatterns)),
     # iCal feed for testing
+    path("ical/", ical_links),
     path("ical/all/", ical_feed),
 ]
 

--- a/src/config/urls.py
+++ b/src/config/urls.py
@@ -53,8 +53,8 @@ urlpatterns = [
     # DW Design System
     path("dwds/", include(dwds_urlpatterns)),
     # iCal feed for testing
-    path("ical/", ical_links),
-    path("ical/all/", ical_feed),
+    path("ical/", ical_links, name="ical_links"),
+    path("ical/all/", ical_feed, name="ical_feed"),
 ]
 
 # If django-silk is installed, add its URLs

--- a/src/events/templates/events/calendar_links.html
+++ b/src/events/templates/events/calendar_links.html
@@ -1,0 +1,4 @@
+<h1>PoC Calendar links</h1>
+<ul>
+    <li><a href="{{ request.build_absolute_uri(reverse('ical_feed')) }}?tk={{ token }}&u={{ request.user.profile.uuid }}">Raw iCal URL (all events + dummy)</a></li>
+</ul>

--- a/src/events/templates/events/calendar_links.html
+++ b/src/events/templates/events/calendar_links.html
@@ -1,4 +1,9 @@
 <h1>PoC Calendar links</h1>
+<p>These links are personal to you, please do not share them.</p>
+<p>The calendar contains all events in the system + a dummy one that starts 10 mins from cal retrieval.</p>
 <ul>
-    <li><a href="{{ request.build_absolute_uri(reverse('ical_feed')) }}?tk={{ token }}&u={{ request.user.profile.uuid }}">Raw iCal URL (all events + dummy)</a></li>
+    <li><a href="{{ raw_uri }}">Raw iCal URL</a> - paste into the correct field in your cal application</li>
+    <li><a href="https://outlook.office.com/owa?path=%2Fcalendar%2Faction%2Fcompose&rru=addsubscription&url={{ encoded_uri }}&name=DBT%20Events" target="_blank">Outlook 365 special link</a></li>
+    <li><a href="https://outlook.office.com/owa?path=%2Fcalendar%2Faction%2Fcompose&rru=addsubscription&url={{ encoded_uri }}&name=DBT%20Events" target="_blank">Outlook Live special link</a></li>
+    <li><a href="https://calendar.google.com/calendar/render?cid={{ encoded_uri }}" target="_blank">Google cal special link</a></li>
 </ul>

--- a/src/events/views.py
+++ b/src/events/views.py
@@ -1,9 +1,12 @@
 from datetime import timedelta
 
+from django.contrib.auth import get_user_model
 from django.http import HttpResponse
 from django.shortcuts import render
+from django.urls import reverse
 from django.utils import timezone
 from django.utils.crypto import get_random_string
+from django.utils.http import urlencode
 from icalendar import Calendar, Event, vCalAddress, vText
 
 from .models import EventPage
@@ -68,21 +71,37 @@ def get_user_token(user):
 
 
 def ical_links(request):
-    return render(request, "events/calendar_links.html", {"token": get_user_token(request.user)})
+    token = get_user_token(request.user)
+    feed_url = request.build_absolute_uri(reverse("ical_feed"))
+    full_uri = f"{feed_url}?tk={token}&u={request.user.profile.slug}"
+    full_uri_encoded = f"{feed_url}%3Ftk={token}%26u={request.user.profile.slug}"
+    return render(
+        request,
+        "events/calendar_links.html",
+        {
+            "token": token,
+            "raw_uri": full_uri,
+            "encoded_uri": full_uri_encoded,
+        },
+    )
 
 
 # This end point needs to be covered by a unique auth mechanism to allow calendar
 # clients to update their feeds without SSO; it uses a token and ought to be
 # behind the VPN protection as well
 def ical_feed(request):
-    user := request.user
-    if user.is_anonymous():
-        uuid = request.GET.get("u", None)
-        user = User.objects.get(uuid=uuid)
-
+    user = request.user
     token = request.GET.get("tk", None)
-    if user is None or token != get_user_token(request.user):
-        return HttpResponse('Unauthorized', status=401)
+    if user.is_anonymous:
+        uuid = request.GET.get("u", None)
+        # some of our calendar link hacks double-parse the URL and can lose
+        # GEt vars after '&' so this is to get around that
+        if uuid is None and "." in token:
+            token, uuid = token.split(".")
+        user = get_user_model().objects.get(profile__slug=uuid)
+
+    if user is None or token != get_user_token(user):
+        return HttpResponse("Unauthorized", status=401)
 
     cal = Calendar()
     cal.add("prodid", "-//intranet-all-events//dbt.gov.uk//")

--- a/src/peoplefinder/migrations/0122_add_ical_token.py
+++ b/src/peoplefinder/migrations/0122_add_ical_token.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("peoplefinder", "0121_merge_20240430_0948"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="person",
+            name="ical_token",
+            field=models.CharField(
+                blank=True,
+                max_length=80,
+                null=True,
+                verbose_name="Individual token for iCal feeds",
+            ),
+        ),
+    ]

--- a/src/peoplefinder/models.py
+++ b/src/peoplefinder/models.py
@@ -541,6 +541,12 @@ class Person(Indexed, models.Model):
     )
     login_count = models.IntegerField(default=0)
     profile_completion = models.IntegerField(default=0)
+    ical_token = models.CharField(
+        verbose_name="Individual token for iCal feeds",
+        blank=True,
+        null=True,
+        max_length=80,
+    )
 
     objects = models.Manager.from_queryset(PersonQuerySet)()
     active = ActivePeopleManager.from_queryset(PersonQuerySet)()

--- a/src/peoplefinder/services/person.py
+++ b/src/peoplefinder/services/person.py
@@ -603,7 +603,7 @@ class PersonAuditLogSerializer(AuditLogSerializer):
     # the audit log code when we update the model. The tests will execute this code so
     # it should fail locally and in CI. If you need to update this number you can call
     # `len(Person._meta.get_fields())` in a shell to get the new value.
-    assert len(Person._meta.get_fields()) == 56, (
+    assert len(Person._meta.get_fields()) == 57, (
         "It looks like you have updated the `Person` model. Please make sure you have"
         " updated `PersonAuditLogSerializer.serialize` to reflect any field changes."
     )


### PR DESCRIPTION
iCal feed endpoint is exempted from SSO auth, though requires a user-specific token generated by visiting the `/ical` endpoint, which also gives access to a few URLs; the main ICS one and a couple of others designed to be "1 click subscribe" URLs for Outlook and Google. NB these are largely undocumented but seem the easiest way for users.