### PR TITLE
INTR-443 - Fix the capitalisation of prev/next links on event page

### DIFF
--- a/src/dw_design_system/dwds/components/link_navigate.html
+++ b/src/dw_design_system/dwds/components/link_navigate.html
@@ -1,5 +1,5 @@
 <div class="dwds-link-navigate">
-    {% include "dwds/components/link_action.html" with link_url=previous_url link_text=previous_text|default:'Previous'|title left=True %}
+    {% include "dwds/components/link_action.html" with link_url=previous_url link_text=previous_text|default:'Previous' left=True %}
     {% if previous_url and next_url %}<span></span>{% endif %}
-    {% include "dwds/components/link_action.html" with link_url=next_url link_text=next_text|default:'Next'|title right=True %}
+    {% include "dwds/components/link_action.html" with link_url=next_url link_text=next_text|default:'Next' right=True %}
 </div>


### PR DESCRIPTION
- [x] JIRA ticket referenced in title
- [x] Title is clear and concise
- [x] Description gives any relevant detail
- [x] Tests are up to date
- [x] Documentation is up to date

PR to fix the capitalisation issue of prev/next months on the event listing page.

/events/

Before
<img width="581" alt="image" src="https://github.com/user-attachments/assets/8be94fb0-3cf9-4095-b00d-b3bb77d1f1bb">

After
<img width="595" alt="image" src="https://github.com/user-attachments/assets/ae3bc531-c747-4ffd-910a-107be96d68f7">
