### PR TITLE
Get the preview images earlier for the homepage

### DIFF
--- a/src/home/models.py
+++ b/src/home/models.py
@@ -288,7 +288,12 @@ class HomePage(BasePage):
         context = super(HomePage, self).get_context(request, *args, **kwargs)
 
         # News
-        news_items = NewsPage.objects.live().public().annotate_with_comment_count()
+        news_items = (
+            NewsPage.objects.select_related("preview_image")
+            .live()
+            .public()
+            .annotate_with_comment_count()
+        )
 
         priority_page_ribbon_text_mapping = {
             pp["page_id"]: pp["ribbon_text"]
@@ -299,7 +304,8 @@ class HomePage(BasePage):
         # Load the priority pages, preserving the order.
         priority_pages = [
             p.specific
-            for p in ContentPage.objects.filter(id__in=priority_page_ids)
+            for p in ContentPage.objects.select_related("preview_image")
+            .filter(id__in=priority_page_ids)
             .annotate_with_comment_count()
             .annotate(ribbon_text=models.F("priority_page__ribbon_text"))
             .order_by("priority_page__sort_order")
@@ -311,7 +317,8 @@ class HomePage(BasePage):
         )
 
         events = (
-            EventPage.objects.live()
+            EventPage.objects.select_related("preview_image")
+            .live()
             .public()
             .filter(event_end__gte=timezone.now())
             .exclude(id__in=priority_page_ids)


### PR DESCRIPTION
Get the preview images for each page shown on the homepage to reduce the query count by the number of pages displayed on the home page. (on my local this was a reduction of 18 queries)