### PR TITLE
Profile completion formatting

### DIFF
--- a/src/peoplefinder/templates/peoplefinder/team.html
+++ b/src/peoplefinder/templates/peoplefinder/team.html
@@ -22,9 +22,8 @@
                             {{ page_title }}
                             {% if team.abbreviation %}({{ team.abbreviation }}){% endif %}
                         </h1>
-
-                        {% if profile_completion %}<p class="text-small">{{ profile_completion }}</p>{% endif %}
                         <div data-testid="description">{{ team.description|markdown }}</div>
+                        {% if profile_completion %}<p class="text-small">{{ profile_completion }}</p>{% endif %}
                         <div class="dwds-button-group">
                             {% if perms.peoplefinder.change_team %}
                                 <a class="dwds-button dwds-button--secondary dwds-button--inline"

--- a/src/peoplefinder/views/team.py
+++ b/src/peoplefinder/views/team.py
@@ -61,8 +61,11 @@ class TeamDetailView(DetailView, PeoplefinderView):
         for sub_team in team_service.get_immediate_child_teams(self.object):
             profile_completion = team_service.profile_completion(sub_team)
             if profile_completion:
+                profile_completion_percentage = round(
+                    float(profile_completion * 100), 2
+                )
                 sub_team.profile_completion = (
-                    f"{profile_completion:.1%} of profiles complete"
+                    f"{profile_completion_percentage:g}% of profiles complete"
                 )
             sub_teams.append(sub_team)
 
@@ -108,8 +111,9 @@ class TeamDetailView(DetailView, PeoplefinderView):
         team_service = TeamService()
 
         if profile_completion := team_service.profile_completion(self.object):
+            profile_completion_percentage = round(float(profile_completion * 100), 2)
             context["profile_completion"] = (
-                f"{profile_completion:.1%} of profiles complete"
+                f"{profile_completion_percentage:g}% of profiles complete"
             )
 
         if self.request.user.has_perm("peoplefinder.delete_team"):


### PR DESCRIPTION
After discussion with the team, some changes were requested:
- When showing the percentage as `50` it should not contain any unnecessary zeros, example `50.0%`
- The profile completion should be lower down in the team bio
  - I've placed it above the buttons as those will be moving in future work.

**Before**
![Screenshot 2024-12-09 at 11 59 44](https://github.com/user-attachments/assets/504f5982-9283-4496-83b9-f71e1bef5e9c)

**After**
![Screenshot 2024-12-09 at 12 00 43](https://github.com/user-attachments/assets/5991ea9d-7b20-45eb-88d9-2ae487317c0f)
