### PR TITLE
Only show bookmark icon on pages

### DIFF
--- a/src/core/templatetags/sidebar.py
+++ b/src/core/templatetags/sidebar.py
@@ -5,6 +5,7 @@ from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.safestring import SafeString
 from waffle import flag_is_active
+from wagtail.models import Page
 
 from core.models.models import SiteAlertBanner
 from home.models import HomePage, QuickLink
@@ -143,12 +144,15 @@ class Bookmark(SidebarPart):
 
     def is_visible(self):
         request = self.context["request"]
+
         if not flag_is_active(request, "new_sidebar"):
             return False
+
         page = self.context.get("self")
         if isinstance(page, HomePage):
             return False
-        return True
+
+        return isinstance(page, Page)
 
     def get_part_context(self):
         user = self.context.get("user")


### PR DESCRIPTION
The bookmarks sidebar part is returning that it should be visible on pages that are NOT a Wagtail Page.

Before:
![Screenshot 2025-01-14 at 16 57 43](https://github.com/user-attachments/assets/3704fb3a-2885-48e8-b76e-ab1f8d166231)

After:
![Screenshot 2025-01-14 at 16 58 57](https://github.com/user-attachments/assets/ea0d2e0c-c953-44a3-a1ba-a16a5e2d1f1b)
