### PR TITLE
Type the `strip_tags_with_newlines` method

### DIFF
--- a/src/content/models.py
+++ b/src/content/models.py
@@ -51,7 +51,7 @@ RICH_TEXT_FEATURES = [
 ]
 
 
-def strip_tags_with_newlines(string):
+def strip_tags_with_newlines(string: str) -> str:
     spaced = string.replace("><", ">\n<")
     return strip_tags(spaced)
 


### PR DESCRIPTION
Add types to the `strip_tags_with_newlines` method so that it is clear that we don't handle anything other than a `str`
