### PR TITLE
Fix the failing builds

### DIFF
--- a/.copilot/image_build_run.sh
+++ b/.copilot/image_build_run.sh
@@ -9,6 +9,8 @@ echo "Running post build script"
 echo "Renaming .env.ci to .env"
 mv ".env.ci" ".env"
 
+export $(cat .env | xargs)
+
 cd src
 
 echo "Running collectstatic"

--- a/.copilot/image_build_run.sh
+++ b/.copilot/image_build_run.sh
@@ -5,8 +5,8 @@ set -e
 
 echo "Running post build script"
 
-echo "Renaming .env.ci to .env"
-mv ".env.ci" ".env"
+echo "Copy .env.ci to .env"
+cp ".env.ci" ".env"
 
 cd src
 
@@ -14,6 +14,6 @@ export DJANGO_SETTINGS_MODULE=config.settings.build
 echo "Running collectstatic"
 python manage.py collectstatic --noinput
 
-echo "Renaming .env to .env.ci"
+echo "Delete the .env file"
 cd ../
-mv ".env" ".env.ci"
+rm ".env"

--- a/.copilot/image_build_run.sh
+++ b/.copilot/image_build_run.sh
@@ -2,20 +2,15 @@
 
 # Exit early if something goes wrong
 set -e
-export DJANGO_SETTINGS_MODULE=config.settings.build
 
 echo "Running post build script"
 
 echo "Renaming .env.ci to .env"
 mv ".env.ci" ".env"
 
-echo "Loading .env"
-set -a
-source .env
-set +a
-
 cd src
 
+export DJANGO_SETTINGS_MODULE=config.settings.build
 echo "Running collectstatic"
 python manage.py collectstatic --noinput
 

--- a/.copilot/image_build_run.sh
+++ b/.copilot/image_build_run.sh
@@ -9,7 +9,10 @@ echo "Running post build script"
 echo "Renaming .env.ci to .env"
 mv ".env.ci" ".env"
 
-export $(cat .env | xargs)
+echo "Loading .env"
+set -a
+source .env
+set +a
 
 cd src
 

--- a/src/config/settings/base.py
+++ b/src/config/settings/base.py
@@ -228,7 +228,7 @@ TEMPLATES = [
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "APP_DIRS": True,
         "DIRS": [
-            Path(PROJECT_ROOT_DIR) / "src" / "dw_design_system",
+            PROJECT_ROOT_DIR / "src" / "dw_design_system",
         ],
         "OPTIONS": {
             "context_processors": [

--- a/src/config/settings/base.py
+++ b/src/config/settings/base.py
@@ -22,7 +22,6 @@ PROJECT_ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.
 
 # Read environment variables using `django-environ`, use `.env` if it exists
 env = environ.Env()
-env.read_env()
 
 # Set required configuration from environment
 # Should be one of the following: "local", "test", "dev", "staging", "training", "prod", "build"

--- a/src/config/settings/base.py
+++ b/src/config/settings/base.py
@@ -17,8 +17,8 @@ from sentry_sdk.integrations.redis import RedisIntegration
 
 
 # Set directories to be used across settings
-BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
-PROJECT_ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+BASE_DIR = Path(__file__).parent.parent.parent
+PROJECT_ROOT_DIR = BASE_DIR.parent
 
 # Read environment variables using `django-environ`, use `.env` if it exists
 env = environ.Env()

--- a/src/config/settings/build.py
+++ b/src/config/settings/build.py
@@ -1,3 +1,17 @@
+import os
+
+import environ
+
+
+# Set directories to be used across settings
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+PROJECT_ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+# Read environment variables using `django-environ`, use `.env` if it exists
+env = environ.Env()
+env_file = os.path.join(PROJECT_ROOT_DIR, ".env")
+if os.path.exists(env_file):
+    env.read_env(env_file)
+
 from .base import *  # noqa
 
 APP_ENV = "build"

--- a/src/config/settings/build.py
+++ b/src/config/settings/build.py
@@ -8,7 +8,8 @@ import environ
 BASE_DIR = Path(__file__).parent.parent.parent
 PROJECT_ROOT_DIR = BASE_DIR.parent
 
-# Read environment variables using `django-environ`, use `.env` if it exists
+# Read environment variables from `.env" file because the build step doesn't
+# have access to the environment.
 env = environ.Env()
 env_file = os.path.join(PROJECT_ROOT_DIR, ".env")
 if os.path.exists(env_file):

--- a/src/config/settings/build.py
+++ b/src/config/settings/build.py
@@ -1,11 +1,13 @@
 import os
+from pathlib import Path
 
 import environ
 
 
 # Set directories to be used across settings
-BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
-PROJECT_ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+BASE_DIR = Path(__file__).parent.parent.parent
+PROJECT_ROOT_DIR = BASE_DIR.parent
+
 # Read environment variables using `django-environ`, use `.env` if it exists
 env = environ.Env()
 env_file = os.path.join(PROJECT_ROOT_DIR, ".env")


### PR DESCRIPTION
The build step is failing as it needs to run `collectstatic`. It does this outside of docker, so there is no env set.
This means that it needs to load a `.env` file. It doesn't look like there is a way to configure paketo buildpack to load this in, so I have opted to move this logic into the `config.settings.build` to keep the nasty code near to the problem.