### PR TITLE
Fix share button when there is a reply form

### DIFF
--- a/src/news/models.py
+++ b/src/news/models.py
@@ -189,6 +189,7 @@ class NewsPage(PageWithTopics):
 
         context = self.get_context(request, **kwargs)
         context["comment_form"] = CommentForm()
+        context["reply_comment_form"] = CommentForm(auto_id="reply_%s")
 
         response = TemplateResponse(request, self.template, context)
 

--- a/src/news/templates/news/news_page.html
+++ b/src/news/templates/news/news_page.html
@@ -55,7 +55,7 @@
                                   onsubmit="setCommentId(this, {{ comment.pk }});">
                                 {% csrf_token %}
                                 <div class="govuk-form-group">
-                                    {% for field in comment_form %}
+                                    {% for field in reply_comment_form %}
                                         <label class="ws-hide" for="{{ field.auto_id }}">Comment content</label>
                                         {{ field }}
                                     {% endfor %}


### PR DESCRIPTION
When there is a comment already on the page, the reply form has a field with the same ID as the main comment form.

This PR fixes this issue by adding an auto_id prefix to the comment form so that it's fields don't overlap with the main comment form.