### PR TITLE
Fixed reactions showing on homepage when disabled

### DIFF
--- a/src/dw_design_system/dwds/elements/page_counts.html
+++ b/src/dw_design_system/dwds/elements/page_counts.html
@@ -9,7 +9,7 @@
             {{ comment_count }} Comment{{ comment_count|pluralize }}
         </div>
     {% endif %}
-    {% if reaction_count > 0 %}
+    {% if FEATURE_FLAGS.show_reactions and reaction_count > 0 %}
         <div class="content-with-icon small-gap">
             <img class="content-icon tiny"
                  src="{% static '/images/dwds/icons/heart.svg' %}"


### PR DESCRIPTION
- [x] JIRA ticket referenced in title
- [x] Title is clear and concise
- [x] Description gives any relevant detail
- [x] Tests are up to date
- [x] Documentation is up to date

Removed the reactions count from the homepage when disabled

![image](https://github.com/user-attachments/assets/e806b558-2e9a-487f-82e4-108669e7d642)
![image](https://github.com/user-attachments/assets/bb672b9f-81a5-4636-a0e7-4fee0e85eee1)