### PR TITLE
Hide useful links when networks hub flag is inactive

### DIFF
--- a/src/core/templatetags/sidebar.py
+++ b/src/core/templatetags/sidebar.py
@@ -289,6 +289,9 @@ class UsefulLinks(SidebarPart):
             )
 
     def is_visible(self) -> bool:
+        if not flag_is_active(self.request, flags.NETWORKS_HUB):
+            return False
+
         page = self.context.get("self")
         if not isinstance(page, Page):
             return False


### PR DESCRIPTION
If the networks hub flag isn't active, don't show useful links