### PR TITLE
INTR-647 - Spotlight component spacing

### DIFF
--- a/src/dw_design_system/dwds/components/spotlight.scss
+++ b/src/dw_design_system/dwds/components/spotlight.scss
@@ -7,4 +7,8 @@
     --content-main-padding: 0;
     --content-main-bg-color: transparent;
   }
+
+  h3 {
+    margin-top: var(--s-1);
+  }
 }

--- a/src/dw_design_system/dwds/components/spotlight.scss
+++ b/src/dw_design_system/dwds/components/spotlight.scss
@@ -5,10 +5,8 @@
 
   .content-main {
     --content-main-padding: 0;
+    padding-top: var(--s0);
     --content-main-bg-color: transparent;
   }
 
-  h3 {
-    margin-top: var(--s-1);
-  }
 }

--- a/src/dw_design_system/dwds/elements/sidebar_part.scss
+++ b/src/dw_design_system/dwds/elements/sidebar_part.scss
@@ -5,10 +5,9 @@
         font-weight: var(--font-weight-bold);
     }
 
-    div {
-        h3 {
-            margin-top: var(--s-1);
-        }
+    > div > h3 {
+        margin-top: var(--s-1);
     }
+
 
 }

--- a/src/dw_design_system/dwds/elements/sidebar_part.scss
+++ b/src/dw_design_system/dwds/elements/sidebar_part.scss
@@ -5,7 +5,10 @@
         font-weight: var(--font-weight-bold);
     }
 
-    h3 {
-        margin-top: var(--s-1);
+    div {
+        h3 {
+            margin-top: var(--s-1);
+        }
     }
+
 }


### PR DESCRIPTION
- [x] JIRA ticket referenced in title
- [x] Title is clear and concise
- [x] Description gives any relevant detail
- [ ] Tests are up to date
- [x] Documentation is up to date

The spotlight should now have the correct margin and the sidebar styling should overwrite said margin.
<img width="730" alt="image" src="https://github.com/user-attachments/assets/f43f259d-9462-4506-8429-2d3c3e235837" />
<img width="1460" alt="image" src="https://github.com/user-attachments/assets/c775ce23-6acb-4683-9b11-bdfba78509e0" />

