### PR TITLE
Fix spotlight image

### DIFF
--- a/src/core/templates/tags/sidebar/parts/spotlight.html
+++ b/src/core/templates/tags/sidebar/parts/spotlight.html
@@ -1,6 +1,6 @@
 <div class="dwds-sidebar-part">
     <div class="dwds-spotlight content-stack medium">
         <h3>Spotlight on...</h3>
-        {% include "dwds/components/engagement.html" %}
+        {% include "dwds/components/engagement.html" with rounded_image=True %}
     </div>
 </div>

--- a/src/dw_design_system/dwds/components/engagement.html
+++ b/src/dw_design_system/dwds/components/engagement.html
@@ -2,7 +2,7 @@
 
 <div class="content-item content-custom-sidebar-wrapper">
     <div class="content-custom-sidebar">
-        {% include "dwds/elements/content_image.html" with content_image=thumbnail %}
+        {% include "dwds/elements/content_image.html" with content_image=thumbnail rounded=rounded_image %}
 
         <div class="content-main content">
             <div class="content-body content-stack">

--- a/src/dw_design_system/dwds/components/one_up.scss
+++ b/src/dw_design_system/dwds/components/one_up.scss
@@ -5,9 +5,11 @@
         > .content-main {
             min-inline-size: var(--one-up-min-inline-size);
         }
-        
+
         > .content-image {
+            background-color: var(--card-bg-white);
             height: 100%;
+
             img {
                 object-position: center;
                 object-fit: contain;

--- a/src/dw_design_system/dwds/components/spotlight.html
+++ b/src/dw_design_system/dwds/components/spotlight.html
@@ -1,1 +1,1 @@
-<div class="dwds-spotlight">{% include "dwds/components/engagement.html" %}</div>
+<div class="dwds-spotlight">{% include "dwds/components/engagement.html" with rounded_image=True %}</div>

--- a/src/dw_design_system/dwds/components/spotlight.scss
+++ b/src/dw_design_system/dwds/components/spotlight.scss
@@ -1,8 +1,4 @@
 .dwds-spotlight {
-  .content-image img {
-    border-radius: var(--border-radius);
-  }
-
   .content-main {
     --content-main-padding: 0;
     --content-main-bg-color: transparent;

--- a/src/dw_design_system/dwds/elements/content_image.scss
+++ b/src/dw_design_system/dwds/elements/content_image.scss
@@ -1,5 +1,4 @@
 .content-image {
-    background-color: var(--card-bg-white);
     margin: 0;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
The spotlight component is showing with a white background and no rounded corners.

Before:
![Screenshot 2025-04-08 at 16 13 46](https://github.com/user-attachments/assets/7a07e221-6edd-42bd-aa42-6e9dccbd8ab1)

After:
![Screenshot 2025-04-08 at 16 14 34](https://github.com/user-attachments/assets/02ccaac9-090e-4b8d-bc7f-da6c71d6b13e)
