### PR TITLE
IDPF-390: add existing people card to Discover view

### DIFF
--- a/src/peoplefinder/services/directory.py
+++ b/src/peoplefinder/services/directory.py
@@ -9,9 +9,10 @@ def get_people(user: User) -> QuerySet[Person]:
     """
     Returns all the people that the given user has permission to see
     """
-    people = Person.objects.all()
-    if user.has_perm("peoplefinder.can_view_inactive_profiles"):
-        return people
+    queryset = Person.objects.all().get_annotated()
 
-    days = settings.SEARCH_SHOW_INACTIVE_PROFILES_WITHIN_DAYS
-    return people.active_or_inactive_within(days=days)
+    if not user.has_perm("peoplefinder.can_view_inactive_profiles"):
+        days = settings.SEARCH_SHOW_INACTIVE_PROFILES_WITHIN_DAYS
+        queryset = queryset.active_or_inactive_within(days=days)
+
+    return queryset

--- a/src/peoplefinder/templates/peoplefinder/discover.html
+++ b/src/peoplefinder/templates/peoplefinder/discover.html
@@ -18,9 +18,18 @@
 
 {% block primary_content %}
     {% if people %}
-        {% for person in people %}
-            <a href="{% url 'profile-view' person.slug %}"class="text-medium">{{ person }}</a>
-        {% endfor %}
+        <div class="content-grid grid-cards-auto-fill">
+            {% for person in people %}
+                <div class="dwds-content-item-card">
+                    {% url 'profile-view' person.slug as profile_url %}
+                    {% if person.photo %}
+                        {% include "dwds/components/profile_info.html" with show_profile_image=True profile_image_url=person.photo.url name=person.full_name title=person.formatted_roles|join:", " location=person.uk_office_location.city profile_url=profile_url %}
+                    {% else %}
+                        {% include "dwds/components/profile_info.html" with show_profile_image=True name=person.full_name title=person.formatted_roles|join:", " location=person.uk_office_location.city profile_url=profile_url %}
+                    {% endif %}
+                </div>
+            {% endfor %}
+        </div>
     {% else %}
         <p>There's no team members to show.</p>
     {% endif %}


### PR DESCRIPTION
Also updated the service to run the annotations for easier access to e.g. job title. We probably want to optimise this but right now it does the job