### PR TITLE
IDPF-401 Add homepage banner for discover view

### DIFF
--- a/src/core/templatetags/sidebar.py
+++ b/src/core/templatetags/sidebar.py
@@ -375,18 +375,19 @@ def sidebar(context):
 
 class DiscoverPage(SidebarPart):
     template_name = "tags/sidebar/parts/site_alert.html"
+
     def is_visible(self) -> bool:
         page = self.context.get("self")
         if not flag_is_active(self.request, flags.PF_DISCOVER):
             return False
         if isinstance(page, HomePage):
             return True
-    
+
     def get_part_context(self) -> dict:
         context = super().get_part_context()
 
         context.update(
-            banner_text="New discover page is available!",
+            banner_text="New 'discover people' page is available!",
             banner_link=reverse("discover"),
         )
         return context

--- a/src/core/templatetags/sidebar.py
+++ b/src/core/templatetags/sidebar.py
@@ -360,6 +360,7 @@ def sidebar(context):
         SidebarSection(
             title="Secondary page actions",
             parts=[
+                DiscoverPage,
                 UsefulLinks,
                 SpotlightPage,
                 YourBookmarks,
@@ -370,3 +371,22 @@ def sidebar(context):
         ),
     ]
     return {"sections": [section for section in sections if section.is_visible()]}
+
+
+class DiscoverPage(SidebarPart):
+    template_name = "tags/sidebar/parts/site_alert.html"
+    def is_visible(self) -> bool:
+        page = self.context.get("self")
+        if not flag_is_active(self.request, flags.PF_DISCOVER):
+            return False
+        if isinstance(page, HomePage):
+            return True
+    
+    def get_part_context(self) -> dict:
+        context = super().get_part_context()
+
+        context.update(
+            banner_text="New discover page is available!",
+            banner_link=reverse("discover"),
+        )
+        return context

--- a/src/core/templatetags/sidebar.py
+++ b/src/core/templatetags/sidebar.py
@@ -339,6 +339,26 @@ class SpotlightPage(SidebarPart):
         return context
 
 
+class DiscoverPage(SidebarPart):
+    template_name = "tags/sidebar/parts/site_alert.html"
+
+    def is_visible(self) -> bool:
+        page = self.context.get("self")
+        if not flag_is_active(self.request, flags.PF_DISCOVER):
+            return False
+        if isinstance(page, HomePage):
+            return True
+
+    def get_part_context(self) -> dict:
+        context = super().get_part_context()
+
+        context.update(
+            banner_text="New 'discover people' page is available!",
+            banner_link=reverse("discover"),
+        )
+        return context
+
+
 @register.inclusion_tag("tags/sidebar.html", takes_context=True)
 def sidebar(context):
     sections: list[SidebarSection] = [
@@ -371,23 +391,3 @@ def sidebar(context):
         ),
     ]
     return {"sections": [section for section in sections if section.is_visible()]}
-
-
-class DiscoverPage(SidebarPart):
-    template_name = "tags/sidebar/parts/site_alert.html"
-
-    def is_visible(self) -> bool:
-        page = self.context.get("self")
-        if not flag_is_active(self.request, flags.PF_DISCOVER):
-            return False
-        if isinstance(page, HomePage):
-            return True
-
-    def get_part_context(self) -> dict:
-        context = super().get_part_context()
-
-        context.update(
-            banner_text="New 'discover people' page is available!",
-            banner_link=reverse("discover"),
-        )
-        return context


### PR DESCRIPTION
- I used the `site_alert.html` template for the DiscoverPage template.
- `banner_text`, is set as "New 'discover people' page is available!" (for now).

- [x] JIRA ticket referenced in title
- [x] Title is clear and concise
- [x] Description gives any relevant detail
- [ ] Tests are up to date
- [ ] Documentation is up to date
