### PR TITLE
Fix the content stack styling as the variable approach isn't working

### DIFF
--- a/src/dw_design_system/dwds/layouts/content_stack.scss
+++ b/src/dw_design_system/dwds/layouts/content_stack.scss
@@ -1,31 +1,37 @@
 .content-stack {
-    --content-stack-gap: var(--s0);
-
     display: flex;
     flex-direction: column;
     justify-content: flex-start;
-}
 
-.content-stack.no-gap {
-    --content-stack-gap: 0;
-}
+    > * {
+        margin-block: 0;
+    }
 
-.content-stack.tiny {
-    --content-stack-gap: var(--s-5);
-}
+    > * + * {
+        margin-block-start: var(--s0);
+    }
 
-.content-stack.small {
-    --content-stack-gap: var(--s-3);
-}
+    &.no-gap {
+        > * + * {
+            margin-block-start: 0;
+        }
+    }
 
-.content-stack.large {
-    --content-stack-gap: var(--space);
-}
+    &.tiny {
+        > * + * {
+            margin-block-start: var(--s-5);
+        }
+    }
 
-.content-stack > * {
-    margin-block: 0;
-}
+    &.small {
+        > * + * {
+            margin-block-start: var(--s-3);
+        }
+    }
 
-.content-stack > * + * {
-    margin-block-start: var(--content-stack-gap);
+    &.large {
+        > * + * {
+            margin-block-start: var(--space);
+        }
+    }
 }


### PR DESCRIPTION
When using the variable approach, `.content-stacks` don't obey the spacing provided by a parent `.content-stack`.

**Example:**
The following are inside a `.content-stack.large` but they have just a class of `.content-stack`. This means they should have larger spacing between components, than between the child elements.
<img width="924" alt="Screenshot 2025-04-15 at 19 53 23" src="https://github.com/user-attachments/assets/26ff3cbd-59f4-4125-af88-c9e23cb45333" />
As we can see, the spacing between the 2 quote components (with just a `content-stack` class have narrower spacing above than the person banner component which has no `content-stack` class.

Below is the same scenario with the style changes from this PR:
<img width="989" alt="Screenshot 2025-04-15 at 19 54 46" src="https://github.com/user-attachments/assets/eec786b6-50b7-4763-8367-b1471e1a982d" />
All of the spacing is correct based on the stack the element is in.
