### PR TITLE
Move the scripts inside the elements so it doesn't impact spacing

### DIFF
--- a/src/core/templates/tags/sidebar/parts/comment.html
+++ b/src/core/templates/tags/sidebar/parts/comment.html
@@ -1,16 +1,16 @@
 {% if page.allow_comments %}
-    <script type="text/javascript">
-        function scrollAndFocus(event, inputId) {
-            event.preventDefault();
-            const input = document.getElementById(inputId);
-            if (input) {
-                input.scrollIntoView({behavior: 'smooth'});
-                input.focus();
-            }
-        }
-    </script>
     <c-dwds-card icon-card="true">
         <c-slot name="card_content">
+            <script type="text/javascript">
+                function scrollAndFocus(event, inputId) {
+                    event.preventDefault();
+                    const input = document.getElementById(inputId);
+                    if (input) {
+                        input.scrollIntoView({behavior: 'smooth'});
+                        input.focus();
+                    }
+                }
+            </script>
             <button class="dwds-button dwds-button--clear-icon content-with-icon no-gap"
                     onClick="scrollAndFocus(event, 'id_comment')"
                     title="Comment section">{% include 'dwds/icons/comment.html' %}</button>

--- a/src/core/templates/tags/sidebar/parts/feedback.html
+++ b/src/core/templates/tags/sidebar/parts/feedback.html
@@ -1,15 +1,15 @@
-<script type="text/javascript">
-    function giveFeedback() {
-        event.preventDefault();
-        const feedbackElement = document.querySelector('.feedback-section details');
-        const feedbackInput = feedbackElement.querySelector('#id_trying_to');
-        feedbackElement.scrollIntoView({behavior: 'smooth'});
-        feedbackElement.open = true;
-        feedbackInput.focus();
-    }
-</script>
 <c-dwds-card>
     <c-slot name="card_content">
+        <script type="text/javascript">
+            function giveFeedback() {
+                event.preventDefault();
+                const feedbackElement = document.querySelector('.feedback-section details');
+                const feedbackInput = feedbackElement.querySelector('#id_trying_to');
+                feedbackElement.scrollIntoView({behavior: 'smooth'});
+                feedbackElement.open = true;
+                feedbackInput.focus();
+            }
+        </script>
         {% include "dwds/components/cta_button.html" with data_testid="give-feedback-button" button_func="giveFeedback()" title=title url=team_url description=description icon="dwds/icons/feedback.html" %}
     </c-slot>
 </c-dwds-card>


### PR DESCRIPTION
When the script tag is the first item in the stack it causes the element after to have margin on the top, but since the script tag is invisible, it results in the sidebar spacing being incorrect