### PR TITLE
Fix image resizing in content

### DIFF
--- a/src/dw_design_system/dwds/components/engagement.html
+++ b/src/dw_design_system/dwds/components/engagement.html
@@ -3,7 +3,6 @@
 <div class="dwds-engagement content-item content-custom-sidebar-wrapper">
     <div class="content-custom-sidebar">
         {% include "dwds/elements/content_image.html" with content_image=thumbnail rounded=rounded_image %}
-
         <div class="content-main content">
             <div class="content-body content-stack">
                 {% if ribbon_text %}

--- a/src/dw_design_system/dwds/components/engagement.scss
+++ b/src/dw_design_system/dwds/components/engagement.scss
@@ -1,5 +1,10 @@
 .dwds-engagement {
-    .content-image {
+    > .content-custom-sidebar > .content-image {
         --content-image-max-height: 400px;
+        max-width: unset;
+
+        > img {
+            max-width: unset;
+        }
     }
 }

--- a/src/dw_design_system/dwds/elements/content_image.scss
+++ b/src/dw_design_system/dwds/elements/content_image.scss
@@ -5,10 +5,13 @@
     display: flex;
     flex-direction: column;
 
+    max-width: 100%;
+
     img {
         // Fill the available space, but don't crop or stretch the image
-        // height: 100%;
         max-height: var(--content-image-max-height);
+        max-width: 100%;
+        height: fit-content;
         width: fit-content;
         object-position: center;
         object-fit: contain;


### PR DESCRIPTION
Before:
<img width="647" alt="Screenshot 2025-04-24 at 16 07 00" src="https://github.com/user-attachments/assets/7631ef0c-8ca6-43f0-9502-daedb302ecde" />

After:
<img width="682" alt="Screenshot 2025-04-24 at 16 06 46" src="https://github.com/user-attachments/assets/cb131736-e551-4e22-9861-978a9f61661e" />
