### PR TITLE
INTR-697 Bugfix: Add sub team set initial parent team 

### DIFF
--- a/src/peoplefinder/templates/peoplefinder/team-add-new-subteam.html
+++ b/src/peoplefinder/templates/peoplefinder/team-add-new-subteam.html
@@ -1,13 +1,10 @@
 {% extends 'dwds_sidebar.html' %}
 
-{% block title %}
-{% endblock title %}
-
 {% block page_title_wrapper %}
 {% endblock page_title_wrapper %}
 
 {% block primary_content %}
-    <h1>Add new sub-team to {{ team.short_name }}</h1>
+    <h1>Add new sub-team to {{ parent_team.short_name }}</h1>
 
     <form method="post">
         {% csrf_token %}
@@ -17,7 +14,7 @@
         <c-dwds-button-group>
             <button class="dwds-button" type="submit">Save team</button>
             <a class="dwds-button dwds-button--secondary"
-               href="{% url 'team-view' team.slug %}">Cancel</a>
+               href="{% url 'team-view' parent_team.slug %}">Cancel</a>
         </c-dwds-button-group>
     </form>
 {% endblock primary_content %}

--- a/src/peoplefinder/views/team.py
+++ b/src/peoplefinder/views/team.py
@@ -208,7 +208,7 @@ class TeamTreeView(DetailView, PeoplefinderView):
 
         team = context["team"]
         team_service = TeamService()
-        page_title = f"All sub-teams ({ team.short_name })"
+        page_title = f"All sub-teams ({team.short_name})"
 
         context.update(
             parent_teams=team_service.get_all_parent_teams(team),
@@ -233,7 +233,7 @@ class TeamAddNewSubteamView(PermissionRequiredMixin, CreateView, PeoplefinderVie
         self.parent_team = Team.objects.get(slug=self.kwargs["slug"])
 
     def get_initial(self):
-        return {"parent_team": self.parent_team}
+        return {"parent_team": self.parent_team.pk}
 
     def get_context_data(self, **kwargs: dict) -> dict:
         context = super().get_context_data(**kwargs)
@@ -243,7 +243,7 @@ class TeamAddNewSubteamView(PermissionRequiredMixin, CreateView, PeoplefinderVie
             page_title=page_title,
             team_breadcrumbs=True,
             extra_breadcrumbs=[(None, page_title)],
-            team=self.parent_team,
+            parent_team=self.parent_team,
             is_root_team=False,
         )
 


### PR DESCRIPTION
When adding a sub team, the parent team wasn't being set correctly, leading to teams being added below the root team.
This PR fixes this bug